### PR TITLE
fcc verification progress on server

### DIFF
--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -3,9 +3,12 @@ const Schema = mongoose.Schema;
 
 const User = new Schema({
     githubId: String,
-    username: String,
+    ghUsername: String,
+    fccUsername: String,
     avatarUrl: String,
-    githubUrl: String
+    githubData: Object,
+    fccCerts: Object,
+    verifiedUser: Boolean
 });
 
 export default mongoose.model('User', User);

--- a/backend/routes/getCerts.js
+++ b/backend/routes/getCerts.js
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+export function getFrontEndCert(username) {
+  return axios.get(`https://www.freecodecamp.com/${username}/front-end-certification`);
+}
+
+export function getBackEndCert(username) {
+  return axios.get(`https://www.freecodecamp.com/${username}/back-end-certification`);
+}
+
+export function getDataVisCert(username) {
+  return axios.get(`https://www.freecodecamp.com/${username}/data-visualization-certification`);
+}

--- a/backend/routes/passportLogin.js
+++ b/backend/routes/passportLogin.js
@@ -26,29 +26,41 @@ passport.use(new Strategy({
   clientSecret: process.env.GITHUB_SECRET,
   callbackURL: 'http://localhost:8080/auth/github/callback'
 }, (accesstoken, refreshToken, profile, done) => {
-    User.findOne({ gihubId: profile.id }, (err, user) => {
+    User.findOne({ githubId: profile.id }, (err, user) => {
 
       if (err) return done(err);
-
-      // user registered previously and exists in database
-      if (user) {
-        return done(err, user);
-      } else {
+      
+      if (!user) {
         // new registration: create ans save user in database
         user = new User({
           githubId: profile.id,
-          username: profile.username,
+          ghUsername: profile.username,
+          fccUsername: profile.username,
           avatarUrl: profile._json.avatar_url,
-          githubUrl: profile.profileUrl
+          githubData: {
+            name: profile._json.name,
+            profileUrl: profile.profileUrl,
+            location: profile._json.location,
+            bio: profile._json.bio,
+            email: profile._json.email,
+            company: profile._json.company,
+            numPublicRepos: profile._json.public_repos,
+            numFollowers: profile._json.followers,
+            numFollowing: profile._json.following
+          }
         });
         user.save((err) => {
           if (!err) {
             return done(err, user);
           }
         });
+      } else {
+        // user registered previously and exists in database
+        console.log('user already exists')
+        return done(err, user);
       }
     });
-}))
+}));
 
 router.get('/auth/github', passport.authenticate('github'));
 

--- a/backend/routes/userRoute.js
+++ b/backend/routes/userRoute.js
@@ -1,5 +1,12 @@
 import express from 'express';
 import passport from 'passport';
+import axios from 'axios';
+import User from '../models/user';
+import { 
+  getFrontEndCert, 
+  getBackEndCert, 
+  getDataVisCert 
+} from './getCerts';
 
 const router = express.Router();
 
@@ -17,11 +24,50 @@ router.get('/api/user', (req, res) => {
 });
 
 router.post('/api/verify-credentials', isAuthenticated, (req, res) => {
-  const { username } = req.body;
+  const { username, mongoId } = req.body;
+  
   console.log(`processing verification for ${username}`);
-  // process verification with FCC here ...
-
-  res.sendStatus(201);
+  
+  // process FCC verification...
+  axios.all([getFrontEndCert(username), getBackEndCert(username), getDataVisCert(username)])
+  .then(axios.spread((frontCert, backCert, dataCert) => {
+    if ((frontCert.request._redirectCount + 
+      backCert.request._redirectCount + 
+      dataCert.request._redirectCount) >= 3 ) {
+      return false;
+    } else {
+      return {
+        frontEnd: frontCert.request._redirectCount === 0 ? true : false,
+        backEnd: backCert.request._redirectCount === 0 ? true : false,
+        dataVis: dataCert.request._redirectCount === 0 ? true : false,
+      }
+    }
+  })).then(certs => {
+    if (!certs) {
+      // user not verified, res with error
+      User.findById(mongoId, (err, user) => {
+        if (err) throw err;
+        
+        user.fccUsername = username;
+        user.verifiedUser = false;
+        user.save();
+        
+        res.status(401).json({ error: 'User cannot be verified' });
+      });
+    } else {
+      // verified user, proceed
+      User.findById(mongoId, (err, user) => {
+        if (err) throw err;
+        
+        user.fccCerts = certs;
+        user.fccUsername = username;
+        user.verifiedUser = true;
+        user.save();
+        
+        res.json({ user });
+      });
+    }
+  });
 });
 
 export default router;

--- a/src/actions/loginActions.js
+++ b/src/actions/loginActions.js
@@ -5,6 +5,6 @@ export function getUserData() {
   return axios.get('/api/user').then(res => { return res.data });
 }
 
-export function verifyUser(username) {
-  return axios.post('/api/verify-credentials', { username } );
+export function verifyUser(username, mongoId) {
+  return axios.post('/api/verify-credentials', { username, mongoId } );
 }

--- a/src/components/LoginPage.js
+++ b/src/components/LoginPage.js
@@ -6,10 +6,7 @@ const LoginPage = () => {
       <div className="ui center aligned segment">
         <h2>Please Login Using GitHub</h2>
         
-        <div className="ui button">
-          <i className="icon github"/>
-          <a href="http://localhost:8080/auth/github">Github</a>
-        </div>
+        <a className="ui button" href="http://localhost:8080/auth/github"><i className="icon github"/> Github</a>
         
         <h4>This app requires freeCodeCamp and GitHub credentials.</h4>
         <h4>To signup, you must have earned at least one freeCodeCamp certification.</h4>

--- a/src/components/PassportPage.js
+++ b/src/components/PassportPage.js
@@ -3,17 +3,20 @@ import { getUserData, verifyUser } from '../actions/loginActions';
 
 class PassportPage extends React.Component {
   state = {
-    username: '',
+    ghUsername: '',
+    fccUsername: '',
     avatarUrl: '',
-    githubUrl: ''
+    mongoId: '',
+    userIsVerified: false,
+    redirect: false
   }
 
   componentDidMount() {
     getUserData().then(
       (res) => {
         if (res) {
-          const { avatarUrl, githubUrl, username } = res;
-          this.setState({ username, avatarUrl, githubUrl });
+          const { ghUsername, fccUsername, avatarUrl, _id } = res;
+          this.setState({ ghUsername, fccUsername, avatarUrl, mongoId: _id });
         }
       },
       (err) => console.log // do something with error? display in UI?
@@ -21,41 +24,29 @@ class PassportPage extends React.Component {
   }
 
   handleChange = (e) => {
-    this.setState({ username: e.target.value });
+    this.setState({ fccUsername: e.target.value });
   }
 
   handleSubmit = (e) => {
     e.preventDefault();
-    verifyUser(this.state.username).then(
+    const { fccUsername, mongoId } = this.state;
+    verifyUser(fccUsername, mongoId).then(
       (res) => {
-        console.log(res);
+        console.log(res.data.user)
+        this.setState({ userIsVerified: true });
       },
-      (error) => {
+      (err) => {
         // redirect somehow with react router back to the login back, ?
-        console.log('user is not authenticated...');
+        this.setState({ userIsVerified: false });
       }
     )
-    // here, we need to do 3 things:
-    //  1) see if user updated username, once we determine this, update db to reflect change
-    //  2) possibly in same route, ping fcc cert URLs to see which earned
-    //  3) return up to date user info, along with FCC cert info and set
-    //     all of this to db & redux store for access on client for setting up profile page.
-    //     Optionally, we can also get even more info from github passport auth, such as:
-    //                                                                             - # of repos
-    //                                                                             - bio
-    //                                                                             - organizations
-    //                                                                             - # followers
-    //                                                                             - location
-    //                                                                             - etc
-    //    we can do this when we first authenticate via passport and build it in to the user schema as an array or object
-    //    possibly so that we can pre-populate some profile information when we finally get to that step
-    //    and just like the username, let them change it if they'd like to.
   }
 
   render() {
     return (
       <div className="ui container">
-        <h1>{`Welcome ${this.state.username}!`}</h1>
+      
+        <h1>{`Welcome ${this.state.ghUsername}!`}</h1>
 
         { this.state.avatarUrl.length > 0 && <div className="ui small image"><img src={this.state.avatarUrl} alt="github avatar"/></div> }
 
@@ -64,7 +55,7 @@ class PassportPage extends React.Component {
         <form onSubmit={this.handleSubmit} className="ui form">
           <div className="four wide field">
             <input
-              value={this.state.username}
+              value={this.state.fccUsername}
               onChange={this.handleChange} />
           </div>
           <button type="submit" className="ui button">Verify Free Code Camp User Data</button>


### PR DESCRIPTION
@stephenjfox @Bigghead @bonham000 Ok, Shav and I made some progress this evening on verifying users eligibility to join based on certs earned, please see comment on line 58 or `userRoute.js` though. Still having a little bit of trouble getting the right data to the client. 

I'm positive the update in the DB is happening as it should because I'm also logging the user on sign in, and when you sign in next, it shows the correctly updated data, it's just not being returned right after it updates correctly like we need it to. Shav's idea from the Slack chat could work well if we can get it working, but I would prefer the data coming directly from the DB.

Also, once we figure this out, we still need to:
 - redirect on failed verification to message that says why they can't join
 - set some kind of token that prevents that route from running again once they've been verified
 - redirect to a true welcome / profile setup page on successful verification