### PR TITLE
added validation for BitBucket and GitLab repos

### DIFF
--- a/backend/routes/gitlabRoute.js
+++ b/backend/routes/gitlabRoute.js
@@ -1,0 +1,24 @@
+import express from 'express'
+import axios from 'axios';
+
+const router = express.Router();
+
+router.post('/api/verify-other-repos', (req, res) => {
+  const { repo_path } = req.body;
+  
+  axios.get(`https://bitbucket.org/${repo_path}`)
+  .then((response) => {
+    console.log(response.request._redirectCount)
+    if (response.request._redirectCount === 0) {
+      res.json({ validPublicRepo: 'true' });
+    } else {
+      res.json({ validPublicRepo: 'false' });
+    }
+  })
+  .catch((err) => {
+    if (err) res.json({ validPublicRepo: 'false' });
+  });
+  
+});
+
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -5,6 +5,7 @@ import mongoose from 'mongoose';
 
 import passportRoute from './routes/passportLogin';
 import userRoute from './routes/userRoute';
+import gitLabRoute from './routes/gitLabRoute'
 
 dotenv.config();
 
@@ -16,5 +17,6 @@ app.use(bodyParser.json());
 
 app.use(passportRoute);
 app.use(userRoute);
+app.use(gitLabRoute);
 
 app.listen(8080, () => console.log('Server is running on localhost:8080'));

--- a/src/actions/repoValidations.js
+++ b/src/actions/repoValidations.js
@@ -1,24 +1,34 @@
 import axios from 'axios';
 
-export function validateRepo(owner, repo) {
+// GITHUB:
+export function validateGithubRepo(owner, repo) {
   return axios.get(`https://api.github.com/repos/${owner}/${repo}`)
-  .then((res) => isContributor(owner, repo));
+  .then((res) => isContributorGithub(owner, repo));
 }
 
-function isContributor(owner, repo) {
+function isContributorGithub(owner, repo) {
   return axios.get(`https://api.github.com/repos/${owner}/${repo}/stats/contributors`)
   .then((res) => {
     return { contributorsList: res.data }
   });
 }
 
-export function searchCommits(owner, repo, user) {
+export function searchGithubCommits(owner, repo, user) {
   return axios.get(`https://api.github.com/search/commits?q=repo:${owner}/${repo}+author:${user}`, {
     headers:  { 'Accept' : 'application/vnd.github.cloak-preview' }
   });
 }
   
-  
-  
+//GITLAB:
+export function validateOtherRepos(repo_path) {
+  return axios.post('/api/verify-other-repos', { repo_path })
+  .then((res) => {
+    if (res.data.validPublicRepo === 'true') {
+      return true;
+    } else {
+      return false;
+    }
+  });
+}
 
   

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -6,6 +6,7 @@ import MessageBox from './common/MessageBox';
 import DividingHeader from './common/DividingHeader';
 import DropdownMultiSelect from './common/DropdownMultiSelect';
 import UserLabel from './common/UserLabel';
+import { saveUser } from '../actions/loginActions';
 
 import { skills, interests } from '../assets/data/dropdownOptions';
 
@@ -63,7 +64,7 @@ class Dashboard extends React.Component {
     });
     
     return (
-      <div id="test" className="ui container">
+      <div id="dashboard-page-main-container" className="ui container">
         <UserLabel 
           label="Contributor"
           username={username}
@@ -110,7 +111,7 @@ class Dashboard extends React.Component {
             header="Would you like to be a mentor?"
             message="The primary goal of this community is to bring together programmers of varying degrees of skill, and connect them with one another to form meaningful mentor/mentee relationships. If you are interested in becoming a mentor, please toggle the switch below. If your skills match with a prospective mentee, you will both be notified, and the rest will be up to you! We will try our best to match you based on interests, skills, location, and language. This feature can be turned off at any time here in your dashboard settings."
           />
-          <div className="ui active toggle checkbox">
+        <div className="ui toggle checkbox">
             <input onClick={this.toggleMentorship} type="checkbox" name="public" />
             <label>Sign me up! I want to be a mentor.</label>
           </div><br /><br />
@@ -171,4 +172,4 @@ Dashboard.propTypes = {
   githubData: React.PropTypes.object.isRequired
 }
 
-export default connect(mapStateToProps)(Dashboard);
+export default connect(mapStateToProps, { saveUser })(Dashboard);

--- a/src/components/PassportPage.js
+++ b/src/components/PassportPage.js
@@ -31,8 +31,7 @@ class PassportPage extends React.Component {
           }
         }
       },
-      (err) => console.log // do something with error? display in UI?
-    );
+    ).catch(console.log); // do something with error? display in UI?
   }
 
   handleClick = (e) => {

--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -34,3 +34,7 @@
 #arrow-bounce {
   animation: bouncey-arrow 1.5s infinite;
 }
+
+#dashboard-page-main-container {
+  margin-bottom: 50px;
+}

--- a/src/utils/requireAuth.js
+++ b/src/utils/requireAuth.js
@@ -9,7 +9,8 @@ export default function requireAuth(ComposedComponent) {
     state = {
       redirect: false
     }
-    componentWillMount() {
+    
+    componentWillMount() {  
       if(!this.props.isVerified) {
         this.props.addFlashMessage({ 
           type: 'error',
@@ -22,6 +23,7 @@ export default function requireAuth(ComposedComponent) {
         this.setState({ redirect: true });
       }
     }
+    
     render() {
       return (
         <div>


### PR DESCRIPTION
- added validations for gitlab and bitbucket repos (for open collaborative projects list) but not on same level as GH, neither host has APIs as robust, so just checking that repo exists and is public
- couple of other small tweaks, including adding margin to bottom of dashboard page
- having trouble overriding semantics styles and making the mentor slider standout more
- also added TODO in repo list component, need to add another layer of validation to be sure user does not add the same repo twice