### PR TITLE
profile: added new fields, panes and control to inputs, plus small style changes

### DIFF
--- a/src/components/common/UserLabel.js
+++ b/src/components/common/UserLabel.js
@@ -27,16 +27,23 @@ UserLabel.propTypes = {
   image: React.PropTypes.string.isRequired,
   username: React.PropTypes.string.isRequired,
   label: React.PropTypes.string.isRequired,
+  toggleAll: React.PropTypes.func,
+  folder: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.bool
+  ])
 }
 
 UserLabel.defaultProps = {
   color: 'teal',
   size: 'medium',
+  folder: ''
 }
 
 export default UserLabel;
 
 // EXAMPLE USAGE (Semantic UI classNames)
+
 // <UserLabel
 //   label="Contributor"
 //   username={username}
@@ -45,3 +52,14 @@ export default UserLabel;
 // />
 //
 // only specify color & size if diff from default
+
+// OR:
+
+// <UserLabel
+//   label="Contributor"
+//   username={username}
+//   size="huge"
+//   image={avatarUrl}
+//   folder={this.state.showAll}
+//   toggleAll={this.toggleAll}
+// />

--- a/src/components/dashboard/Profile.js
+++ b/src/components/dashboard/Profile.js
@@ -24,11 +24,24 @@ class Profile extends React.Component {
     skills: [],
     certs: [],
     mentor: false,
+    /* technically not cool, but not seeing the choice if we want to autofill and manage state */
+    displayName: this.props.githubData.name ? this.props.githubData.name : '',
+    email: this.props.email ? this.props.email : '',
+    location: this.props.githubData.location ? this.props.githubData.location : '',
+    bio: this.props.githubData.bio ? this.props.githubData.bio : '',
+    /****/
+    codepen: '',
+    twitter: '',
+    linkedin: '',
+    /****/
     showAll: false,
-    showProfile: false,
+    showProfile: true,
     showFCC: false,
     showMentorship: false,
-    showSkills: false
+    showSkills: false,
+    showSocial: false,
+    showCareer: false
+    // ^^ was thinking about putting these into an object for organization of the state object...
   }
   componentDidMount() {
     const { fccCerts } = this.props.user;
@@ -41,7 +54,7 @@ class Profile extends React.Component {
     this.setState({ certs });
   }
 
-  saveList = (items_list) => {
+  saveProjectsList = (items_list) => {
     this.setState({ projects: items_list });
   }
 
@@ -55,6 +68,10 @@ class Profile extends React.Component {
 
   handleInterestsChange = (e, data) => {
     this.setState({ interests: data.value });
+  }
+  
+  handleInputChange = (e) => {
+    this.setState({ [e.target.name] : e.target.value });
   }
 
   toggle = (target) => {
@@ -80,12 +97,16 @@ class Profile extends React.Component {
       showProfile: !this.state.showAll,
       showFCC: !this.state.showAll,
       showMentorship: !this.state.showAll,
-      showSkills: !this.state.showAll
+      showSkills: !this.state.showAll,
+      showSocial: !this.state.showAll,
+      showCareer: !this.state.showAll
     });
   }
 
   render() {
-    const { avatarUrl, username, email } = this.props.user;
+    console.log(this.state)
+    const { username } = this.props.user;
+    const { githubData } = this.props;
 
     const certificates = this.state.certs.map((item, index) => {
       return (
@@ -97,104 +118,212 @@ class Profile extends React.Component {
 
     return (
       <div id="profile-page-main-container" className="ui container">
+        
         <UserLabel
-          label="Contributor"
+          label={this.state.mentor ? 'Mentor' : 'Member'}
           username={username}
           size="huge"
-          image={avatarUrl}
+          image={this.props.user.avatarUrl}
           folder={this.state.showAll}
           toggleAll={this.toggleAll}
         />
+      
+      {/* Does nothing for the time being */}
+      <div style={{ float: 'right' }} className="ui huge teal label">
+        Save
+        <div className="detail">
+          <i className="save icon" />
+        </div>
+      </div>
 
         <div className="ui raised segment">
-
-          <div className="ui teal ribbon label profileWrapper" onClick={this.toggle.bind(this, 'showProfile')}>Personal Info</div>
+          
+          <form className="ui form">
+            
+            <div className="ui teal ribbon label profileWrapper" onClick={this.toggle.bind(this, 'showProfile')}>Personal Info</div>
             <div className={`profilePane ${this.state.showProfile ? 'show' : 'hide'}`}>
               <div className="ui list">
+                
                 <ListItem icon="spy icon">
                   {username}
                 </ListItem>
+                
                 <ListItem icon="github icon">
-                  <a href={this.props.githubData.profileUrl} target="_blank">GitHub Profile</a>
+                  <a href={githubData.profileUrl} target="_blank">GitHub Profile</a>
                 </ListItem>
+                
                 <ListItem>
-                  <div className="ui left icon input mini">
+                  <div className="ui transparent left icon input">
                     <i className="user icon" />
-                    <input type="text" placeholder="Display Name" value={this.props.githubData.name} />
+                    <input
+                      onChange={this.handleInputChange} 
+                      type="text" 
+                      placeholder="Enter Display Name..." 
+                      title="Display Name" 
+                      name="displayName" 
+                      value={this.state.displayName} 
+                      />
                   </div>
                 </ListItem>
+                
                 <ListItem>
-                  <div className="ui left icon input mini">
+                  <div className="ui transparent left icon input">
                     <i className="mail icon" />
-                    <input type="email" placeholder="Enter Email" value={email} />
+                    <input
+                      onChange={this.handleInputChange} 
+                      type="email" 
+                      placeholder="Enter Email..." 
+                      title="Email" 
+                      name="email" 
+                      value={this.state.email} 
+                      />
                   </div>
                 </ListItem>
+                
                 <ListItem>
-                  <div className="ui left icon input mini">
+                  <div className="ui transparent left icon input">
                     <i className="marker icon" />
-                    <input type="text" placeholder="Enter Location" value={this.props.githubData.location} />
+                    <input
+                      onChange={this.handleInputChange} 
+                      type="text" 
+                      placeholder="Enter Location..." 
+                      title="Location" 
+                      name="location" 
+                      value={this.state.location} 
+                      />
                   </div>
                 </ListItem>
+                
+              </div>
+              <div className="ui six wide field">
+                <label>Bio</label>
+                <textarea
+                  onChange={this.handleInputChange} 
+                  name='bio'
+                  rows="4"
+                  value={this.state.bio}
+                  />
               </div>
             </div>
-
-          <div className="ui teal ribbon label fccWrapper" onClick={this.toggle.bind(this, 'showFCC')}>freeCodeCamp Certifications</div>
-          <div className={`ui list fccPane ${this.state.showFCC ? 'show' : 'hide'}`}>
-            {certificates}
-          </div>
-
-          <div className="ui teal ribbon label mentorshipWrapper" onClick={this.toggle.bind(this, 'showMentorship')}>Mentorship Program</div>
-          <div className={`mentorshipPane ${this.state.showMentorship ? 'show' : 'hide'}`}>
-            <MessageBox
-              type="info"
-              header="Would you like to be a mentor?"
-              message="The primary goal of this community is to bring together programmers of varying degrees of skill, and connect them with one another to form meaningful mentor/mentee relationships. If you are interested in becoming a mentor, please toggle the switch below. If your skills match with a prospective mentee, you will both be notified, and the rest will be up to you! We will try our best to match you based on interests, skills, location, and language. This feature can be turned off at any time here in your dashboard settings."
-            />
-            <SliderToggle
-              label="Sign me up! I want to be a mentor!"
-              saveStateToParent={this.toggleMentorship}
-            />
-          </div>
-
-        <div className="ui teal ribbon label skillsWrapper" onClick={this.toggle.bind(this, 'showSkills')}>Skills & Interests</div>
-
-          <div className={`skillsPane ${this.state.showSkills ? 'show' : 'hide'}`}>
-            <DividingHeader text="Core Skills" />
-            <MessageBox
-              type="info"
-              dismissable={true}
-              message="Enter information about your coding skills below, so other users know your strengths!"
-            />
-            <DropdownMultiSelect
-              onChange={this.handleSkillsChange}
-              options={skills}
-              placeholder="Choose Skills"
-            />
-
-            <DividingHeader text="Coding Interests" />
-            <MessageBox
-              type="info"
-              dismissable={true}
-              message="Let other users know what you're into so you can find others with similar interetsts!"
-            />
-            <DropdownMultiSelect
-              onChange={this.handleInterestsChange}
-              options={interests}
-              placeholder="Choose Interests"
-            />
-
-            <DividingHeader text="Open Collaborative Projects" />
-            <MessageBox
-              type="info"
-              dismissable={true}
-              message="Share links to repos for projects that you could use some help with!"
-            />
-            <RepoList
-              saveListToParent={this.saveList}
-              username={username}
-              prePopulateList={this.state.projects}
-            />
-          </div>
+            
+            <div className="ui teal ribbon label fccWrapper" onClick={this.toggle.bind(this, 'showFCC')}>freeCodeCamp Certifications</div>
+            <div className={`ui list fccPane ${this.state.showFCC ? 'show' : 'hide'}`}>
+              {certificates}
+            </div>
+            
+            <div className="ui teal ribbon label mentorshipWrapper" onClick={this.toggle.bind(this, 'showMentorship')}>Mentorship Program</div>
+            <div className={`mentorshipPane ${this.state.showMentorship ? 'show' : 'hide'}`}>
+              <MessageBox
+                type="info"
+                header="Would you like to be a mentor?"
+                message="The primary goal of this community is to bring together programmers of varying degrees of skill, and connect them with one another to form meaningful mentor/mentee relationships. If you are interested in becoming a mentor, please toggle the switch below. If your skills match with a prospective mentee, you will both be notified, and the rest will be up to you! We will try our best to match you based on interests, skills, location, and language. This feature can be turned off at any time here in your dashboard settings."
+                />
+              <SliderToggle
+                label="Sign me up! I want to be a mentor!"
+                saveStateToParent={this.toggleMentorship}
+                />
+            </div>
+            
+            <div className="ui teal ribbon label skillsWrapper" onClick={this.toggle.bind(this, 'showSkills')}>Skills & Interests</div>
+            
+            <div className={`skillsPane ${this.state.showSkills ? 'show' : 'hide'}`}>
+              <DividingHeader text="Core Skills" />
+              <MessageBox
+                type="info"
+                dismissable={true}
+                message="Enter information about your coding skills below, so other users know your strengths!"
+                />
+              <DropdownMultiSelect
+                onChange={this.handleSkillsChange}
+                options={skills}
+                placeholder="Choose Skills"
+                />
+              
+              <DividingHeader text="Coding Interests" />
+              <MessageBox
+                type="info"
+                dismissable={true}
+                message="Let other users know what you're into so you can find others with similar interetsts!"
+                />
+              <DropdownMultiSelect
+                onChange={this.handleInterestsChange}
+                options={interests}
+                placeholder="Choose Interests"
+                />
+              
+              <DividingHeader text="Open Collaborative Projects" />
+              <MessageBox
+                type="info"
+                dismissable={true}
+                message="Share links to repos for projects that you could use some help with!"
+                />
+              <RepoList
+                saveListToParent={this.saveProjectsList}
+                username={username}
+                prePopulateList={this.state.projects}
+                />
+            </div>
+            
+            <div className="ui teal ribbon label socialWrapper" onClick={this.toggle.bind(this, 'showSocial')}>Social</div>
+            <div className={`socialPane ${this.state.showSocial ? 'show' : 'hide'}`}>
+              <MessageBox 
+                type="info"
+                dismissable={true}
+                message="Stay connected with campers on other networks! Let us know where your profiles live."
+              />
+              <div className="ui list">
+                
+                <ListItem>
+                  <div className="ui left icon input mini">
+                    <i className="codepen icon" />
+                    <input
+                      onChange={this.handleInputChange} 
+                      type="text" 
+                      placeholder="Enter CodePen" 
+                      title="CodePen" 
+                      name="codepen"
+                      value={this.state.codepen} 
+                      />
+                  </div>
+                </ListItem>
+                
+                <ListItem>
+                  <div className="ui left icon input mini">
+                    <i className="twitter icon" />
+                    <input
+                      onChange={this.handleInputChange} 
+                      type="text" 
+                      placeholder="Enter Twitter" 
+                      title="Twitter" 
+                      name="twitter"
+                      value={this.state.twitter} 
+                      />
+                  </div>
+                </ListItem>
+                
+                <ListItem>
+                  <div className="ui left icon input mini">
+                    <i className="linkedin icon" />
+                    <input
+                      onChange={this.handleInputChange} 
+                      type="text" 
+                      placeholder="Enter LinkedIn" 
+                      title="LinkedIn" 
+                      name="linkedin"
+                      value={this.state.linkedin} 
+                      />
+                  </div>
+                </ListItem>
+                
+              </div>
+            </div>
+            
+            <div className="ui teal ribbon label careerWrapper" onClick={this.toggle.bind(this, 'showCareer')}>Career</div>
+            <div className={`careerPane ${this.state.showCareer ? 'show' : 'hide'}`}>
+              <h4>Career form goes here...</h4>
+            </div>
+            
+          </form>
 
         </div>
       </div>

--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -38,6 +38,3 @@
   animation: bouncey-arrow 1.5s infinite;
 }
 
-#profile-page-main-container {
-  margin-bottom: 50px;
-}

--- a/src/styles/components/_ProfileStyles.scss
+++ b/src/styles/components/_ProfileStyles.scss
@@ -1,3 +1,6 @@
+#profile-page-main-container {
+  margin-bottom: 50px;
+}
 
 .folderDetail:hover {
   cursor: pointer;
@@ -6,28 +9,51 @@
   }
 }
 
-.profileWrapper:hover, .fccWrapper:hover, .mentorshipWrapper:hover, .skillsWrapper:hover {
+.profileWrapper, 
+.fccWrapper, 
+.mentorshipWrapper, 
+.skillsWrapper,
+.socialWrapper,
+.careerWrapper {
   cursor: pointer;
 }
 
-.profilePane, .fccPane, .mentorshipPane, .skillsPane {
+.profilePane, 
+.fccPane, 
+.mentorshipPane, 
+.skillsPane,
+.socialPane,
+.careerPane {
   padding-top: 8px;
   padding-bottom: 8px;
 }
 
-.profilePane.hide, .fccPane.hide, .mentorshipPane.hide, .skillsPane.hide {
+.profilePane.hide, 
+.fccPane.hide, 
+.mentorshipPane.hide, 
+.skillsPane.hide,
+.socialPane.hide,
+.careerPane.hide {
   overflow: hidden;
   opacity: 0.01;
   max-height: 0;
+  margin-bottom: 0;
   transition:
-    opacity 600ms ease-out,
-    max-height 500ms ease;
+    opacity 400ms ease-out,
+    max-height 300ms ease;
 }
 
-.profilePane.show, .fccPane.show, .mentorshipPane.show, .skillsPane.show {
+.profilePane.show, 
+.fccPane.show, 
+.mentorshipPane.show, 
+.skillsPane.show,
+.socialPane.show,
+.careerPane.show {
   opacity: 1.0;
   max-height: 700px;
+  margin-bottom: 10px;
   transition:
-    opacity 1000ms ease-in,
-    max-height 900ms ease-out;
+    opacity 500ms ease-in,
+    max-height 400ms ease-out;
 }
+

--- a/src/styles/components/_SliderToggle.scss
+++ b/src/styles/components/_SliderToggle.scss
@@ -3,6 +3,7 @@
   margin: 20px 0 20px 0px;
   padding-top: 5px;
   padding-left: 5px; 
+  margin-bottom: 0;
   .slider-label {
     vertical-align: top;
   }


### PR DESCRIPTION
In a rush, may be a tid bit sloppy, but maybe not

### Done:
- added bio field
- added social pane and codepen, linkedin, and twitter fields
- added career pane as a placeholder
- changed to transparent inputs for "Personal Info" section to normalize appearance... thoughts? Needs slight alignment adjustment
- added animations to new panes
- made small adjustments to pane styles to normalize spacing when folded 
- added "Save" button that currently does nothing 

### TODO:
- connect to redux and add validations to form fields on client
- add errors to every form field

One thing on the animations - I played around with the timing a bit on the transitions - one thing you would not have noticed since you have all 3 certs, is with the previous timing, it appears a little choppy if only one cert is earned, because the animation takes the same amount of time as the ones with larger heights, even though much less space is being covered. I think we can use some SASS logic to change the timing based on height of element. This might be less choppy and a better effect all around. Great work though, seriously. 