### PR TITLE
Full implementation of private chat v1

### DIFF
--- a/server/chat/chat.js
+++ b/server/chat/chat.js
@@ -63,32 +63,48 @@ module.exports = (io) => {
 
   io.on('connection', (socket) => {
 
-    // new client connects, send them the current chat history
     console.log('Socket.io connected');
     redis.get('chat', (err, history) => initalizeClient(socket, history));
 
-    // client submits message
+    // GLOBAL CHAT events ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
   	socket.on('submission', (data) => {
       saveMessage(data);
       socket.broadcast.emit('broadcast-message', data);
   	});
 
-    // client edits a message
     socket.on('update-message', (data) => {
       saveUpdate(data);
       socket.broadcast.emit('broadcast-update', data);
     });
 
-    // client likes a message
     socket.on('like-message', ({ messageId, liker }) => {
       saveLike(messageId, liker);
       socket.broadcast.emit('broadcast-like', { messageId, liker });
     });
 
-    // client deletes a message
     socket.on('delete-message', id => {
       registerDelete(id);
       socket.broadcast.emit('broadcast-deletion', id);
+    });
+
+    // PRIVATE-CHAT events ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // only triggered from client after successful database update ~~~~~~
+
+    socket.on('private-submission', (data) => {
+      socket.broadcast.emit('broadcast-private-submission', data);
+    });
+
+    socket.on('private-update', (data) => {
+      socket.broadcast.emit('broadcast-private-update', data);
+    });
+
+    socket.on('private-like', (data) => {
+      socket.broadcast.emit('broadcast-private-like', data);
+    });
+
+    socket.on('private-delete', (data) => {
+      socket.broadcast.emit('broadcast-private-delete', data);
     });
 
     socket.on('disconnect', () => console.log('Socket connection closed'));;

--- a/server/models/private-chat.js
+++ b/server/models/private-chat.js
@@ -3,7 +3,15 @@ const Schema = mongoose.Schema;
 
 const PrivateChat = new Schema({
   members: Array,
-  history: Array
+  history: [{
+    id: String,
+    timestamp: Number,
+    text: String,
+    author: String,
+    avatar: String,
+    likes: Array,
+    edited: Boolean,
+  }]
 });
 
 export default mongoose.model('PrivateChat', PrivateChat);

--- a/server/routes/private-chat.js
+++ b/server/routes/private-chat.js
@@ -10,7 +10,7 @@ const router = express.Router();
 router.get('/api/private-chat/initialize', isAuthenticated, (req, res) => {
   const { username } = req.user;
   PrivateChat.find({ members: username }, (err, history) => {
-    if (err) throw err;
+    if (err) throw res.sendStatus(500);
     res.json(history);
   });
 });
@@ -19,33 +19,89 @@ router.get('/api/private-chat/initialize', isAuthenticated, (req, res) => {
 router.post('/api/private-chat/add-message', isAuthenticated, (req, res) => {
   const { username } = req.user;
   PrivateChat.findOne({ $and: [{members: username}, {members: req.body.reciepient}] }, (err, conversation) => {
-    if (err) throw err;
+    if (err) res.sendStatus(500);
     if (!conversation) {
       const chat = new PrivateChat({
         members: [ username, req.body.reciepient ],
         history: [ req.body ]
       });
-      chat.save();
+      chat.save(e => {
+        if (e) res.sendStatus(500);
+        res.sendStatus(200);
+      });
     } else {
       conversation.history.push(req.body);
-      conversation.save();
+      conversation.save(e => {
+        if (e) res.sendStatus(500);
+        res.sendStatus(200);
+      });
     }
-    res.end();
   });
 });
 
 // save a like event
 router.post('/api/private-chat/like-message', isAuthenticated, (req, res) => {
+  const { id, conversant } = req.body;
+  const { username } = req.user;
+
+  PrivateChat.findOne({ $and: [{members: username}, {members: conversant }] }, (err, chat) => {
+    if (err) res.sendStatus(500);
+    if (chat) {
+      chat.history = chat.history.map(message => {
+        if (message.id === id) message.likes.push(username);
+        return message;
+      })
+      chat.save(e => {
+        if (e) res.sendStatus(500);
+        res.sendStatus(200);
+      });
+    } else {
+      res.sendStatus(404);
+    }
+  });
 
 });
 
 // handle editing message
 router.post('/api/private-chat/edit-message', isAuthenticated, (req, res) => {
+  const { id, text, conversant } = req.body;
+  const { username } = req.user;
+
+    PrivateChat.findOne({ $and: [{members: username}, {members: conversant }] }, (err, chat) => {
+      if (err) res.sendStatus(500);
+      if (chat) {
+        chat.history = chat.history.map(message => {
+          if (message.id === id) message.text = text;
+          return message;
+        })
+        chat.save(e => {
+          if (e) res.sendStatus(500);
+          res.sendStatus(200);
+        });
+      } else {
+        res.sendStatus(404);
+      }
+    });
 
 });
 
 // handle message deletion
-router.post('/api/private-chat/edit-message', isAuthenticated, (req, res) => {
+router.post('/api/private-chat/delete-message', isAuthenticated, (req, res) => {
+  const { id, conversant } = req.body;
+  const { username } = req.user;
+
+  PrivateChat.findOne({ $and: [{members: username}, {members: conversant }] }, (err, conversation) => {
+    if (err) res.sendStatus(500);
+    if (conversation) {
+      conversation.history = conversation.history.filter(m => m.id !== id);
+      conversation.save(e => {
+        if (e) res.sendStatus(500);
+        res.sendStatus(200);
+      });
+    } else {
+      res.sendStatus(404);
+    }
+  });
 
 });
 

--- a/src/actions/chat.js
+++ b/src/actions/chat.js
@@ -3,6 +3,7 @@ import axios from 'axios';
 import uuidV1 from 'uuid/v1';
 import { Map, Set } from 'immutable';
 import { store } from '../index.js';
+import { addFlashMessage } from './flashMessages';
 
 // setup socket.io connection
 const DEV_HOST = 'http://localhost:8080';
@@ -12,21 +13,23 @@ export const socket = require('socket.io-client').connect(DEV_HOST);
 export const INITIALIZE = 'INITIALIZE';
 export const ADD_MESSAGE = 'ADD_MESSAGE';
 export const EDIT_MESSAGE = 'EDIT_MESSAGE';
-export const DELETE_MESSAGE = 'DELETE_MESSAGE';
 export const LIKE_MESSAGE = 'LIKE_MESSAGE';
-export const RECEIVED_LIKE = 'RECEIVED_LIKE';
+export const DELETE_MESSAGE = 'DELETE_MESSAGE';
 export const RECEIVED_MESSAGE = 'RECEIVED_MESSAGE';
+export const RECEIVED_LIKE = 'RECEIVED_LIKE';
 export const RECEIVED_UPDATE = 'RECEIVED_UPDATE';
 
+export const PRIVATE_ERROR = 'PRIVATE_ERROR';
 export const POPULATE_PRIVATE = 'POPULATE_PRIVATE';
 export const INITIALIZE_PRIVATE = 'INITIALIZE_PRIVATE';
 export const ADD_MESSAGE_PRIVATE = 'ADD_MESSAGE_PRIVATE';
 export const EDIT_MESSAGE_PRIVATE = 'EDIT_MESSAGE_PRIVATE';
-export const DELETE_MESSAGE_PRIVATE = 'DELETE_MESSAGE_PRIVATE';
 export const LIKE_MESSAGE_PRIVATE = 'LIKE_MESSAGE_PRIVATE';
-export const RECEIVED_LIKE_PRIVATE = 'RECEIVED_LIKE_PRIVATE';
+export const DELETE_MESSAGE_PRIVATE = 'DELETE_MESSAGE_PRIVATE';
 export const RECEIVED_MESSAGE_PRIVATE = 'RECEIVED_MESSAGE_PRIVATE';
+export const RECEIVED_LIKE_PRIVATE = 'RECEIVED_LIKE_PRIVATE';
 export const RECEIVED_UPDATE_PRIVATE = 'RECEIVED_UPDATE_PRIVATE';
+export const RECEIVED_DELETE_PRIVATE = 'RECEIVED_DELETE_PRIVATE';
 
 /** PRIVATE CHAT ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
@@ -42,9 +45,12 @@ const populatePrivateChat = (user, data) => {
 
 export const fetchPrivateChat = (user) => {
   return dispatch => {
-    return axios.get('/api/private-chat/initialize').then(res => {
-      dispatch(populatePrivateChat(user, res.data));
-    });
+    return axios.get('/api/private-chat/initialize')
+      .then(res => {
+        dispatch(populatePrivateChat(user, res.data));
+      }).catch(err => {
+        dispatch(addFlashMessage('There was an error loading the messages.'))
+      });
   }
 };
 
@@ -54,6 +60,72 @@ export const initiatePrivateChat = (author) => {
     payload: author
   }
 };
+
+socket.on('broadcast-private-submission', data => {
+  console.log('received private message:', data);
+  const { author, reciepient, message } = data;
+  const user = store.getState().user.username;
+  if (user === reciepient) {
+    message.likes = Set();
+    store.dispatch({
+      type: RECEIVED_MESSAGE_PRIVATE,
+      payload: {
+        author,
+        reciepient,
+        message
+      }
+    });
+  };
+});
+
+socket.on('broadcast-private-update', data => {
+  console.log('received private update:', data);
+  const { author, reciepient, id, text } = data;
+  const user = store.getState().user.username;
+  if (user === reciepient) {
+    store.dispatch({
+      type: RECEIVED_UPDATE_PRIVATE,
+      payload: {
+        author,
+        reciepient,
+        id,
+        text
+      }
+    });
+  }
+});
+
+socket.on('broadcast-private-like', data => {
+  console.log('received private like:', data);
+  const { liker, reciepient, id } = data;
+  const user = store.getState().user.username;
+  if (user === reciepient) {
+    store.dispatch({
+      type: RECEIVED_LIKE_PRIVATE,
+      payload: {
+        liker,
+        reciepient,
+        id,
+      }
+    });
+  }
+});
+
+socket.on('broadcast-private-delete', data => {
+  console.log('received private delete:', data);
+  const { author, reciepient, id } = data;
+  const user = store.getState().user.username;
+  if (user === reciepient) {
+    store.dispatch({
+      type: RECEIVED_DELETE_PRIVATE,
+      payload: {
+        author,
+        reciepient,
+        id,
+      }
+    });
+  }
+});
 
 /** ALL CHAT ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
@@ -65,7 +137,7 @@ socket.on('initalize-chat', (data) => {
   });
 });
 
-socket.on('broadcast-message', (message) => {
+socket.on('broadcast-message', message => {
   message.likes = Set();
   store.dispatch({
     type: RECEIVED_MESSAGE,
@@ -73,7 +145,7 @@ socket.on('broadcast-message', (message) => {
   });
 });
 
-export const addMessage = (payload) => {
+export const addMessage = payload => {
   const { author, text, conversant } = payload;
   let message = Map({
     text,
@@ -86,13 +158,20 @@ export const addMessage = (payload) => {
   });
   if (conversant) {
     message = message.set('reciepient', conversant);
-    axios.post('/api/private-chat/add-message', message);
-    return {
-      type: ADD_MESSAGE_PRIVATE,
-      payload: {
-        message,
-        reciepient: conversant
-      }
+    return dispatch => {
+      return axios.post('/api/private-chat/add-message', message)
+        .then(res => {
+          socket.emit('private-submission', { author: message.author, reciepient: conversant, message });
+          dispatch({
+            type: ADD_MESSAGE_PRIVATE,
+            payload: {
+              message,
+              reciepient: conversant
+            }
+          });
+       }).catch(err => {
+         dispatch(addFlashMessage('Could not add message.'));
+       });
     }
   } else {
     socket.emit('submission', message);
@@ -103,32 +182,7 @@ export const addMessage = (payload) => {
   }
 };
 
-export const deleteMessage = (id, conversant) => {
-  if (conversant) {
-    return {
-      type: DELETE_MESSAGE_PRIVATE,
-      payload: {
-        id,
-        reciepient: conversant
-      }
-    }
-  } else {
-    socket.emit('delete-message', id);
-    return {
-      type: DELETE_MESSAGE,
-      payload: { id }
-    }
-  }
-};
-
-socket.on('broadcast-deletion', (id) => {
-  store.dispatch({
-    type: DELETE_MESSAGE,
-    payload: { id }
-  });
-})
-
-socket.on('broadcast-update', (message) => {
+socket.on('broadcast-update', message => {
   message.likes = Set(message.likes);
   store.dispatch({
     type: RECEIVED_UPDATE,
@@ -137,16 +191,7 @@ socket.on('broadcast-update', (message) => {
 });
 
 export const saveEdit = (id, text, conversant) => {
-  if (conversant) {
-    return {
-      type: EDIT_MESSAGE_PRIVATE,
-      payload: {
-        id,
-        text,
-        reciepient: conversant
-      }
-    }
-  } else {
+  if (!conversant) {
     return {
       type: EDIT_MESSAGE,
       payload: {
@@ -154,12 +199,29 @@ export const saveEdit = (id, text, conversant) => {
         text
       }
     };
+  } else {
+    return { type: null }
   }
 };
 
-export const broadcastEdit = (id, conversant) => {
+export const broadcastEdit = (id, text, conversant, author) => {
   if (conversant) {
-    // private socket action here
+    return dispatch => {
+      return axios.post('/api/private-chat/edit-message', { id, text, conversant })
+        .then(res => {
+          socket.emit('private-update', { author, reciepient: conversant, id, text });
+          dispatch({
+            type: EDIT_MESSAGE_PRIVATE,
+            payload: {
+              id,
+              text,
+              reciepient: conversant
+            }
+          })
+        }).catch(err => {
+          dispatch(addFlashMessage('Could not edit message.'))
+        });
+    }
   } else {
     const message = store.getState().chat.find(d => d.get('id') === id).toJS();
     socket.emit('update-message', message);
@@ -174,19 +236,27 @@ socket.on('broadcast-like', ({ messageId, liker }) => {
       messageId,
       liker
     }
-  })
+  });
 });
 
 export const likeMessage = (messageId, liker, conversant) => {
   if (conversant) {
-    // private socket action here
-    return {
-      type: LIKE_MESSAGE_PRIVATE,
-      payload: {
-        messageId,
-        liker,
-        reciepient: conversant
-      }
+    if (liker === conversant) return { type: null };
+    return dispatch => {
+      return axios.post('/api/private-chat/like-message', { id: messageId, conversant })
+        .then(res => {
+          socket.emit('private-like', { liker, reciepient: conversant, id: messageId });
+          dispatch({
+            type: LIKE_MESSAGE_PRIVATE,
+              payload: {
+                messageId,
+                liker,
+                reciepient: conversant
+              }
+            });
+        }).catch(err => {
+          dispatch(addFlashMessage('Could not submit the like to the server right now.'));
+        });
     }
   } else {
     socket.emit('like-message', { messageId, liker });
@@ -199,3 +269,36 @@ export const likeMessage = (messageId, liker, conversant) => {
     }
   }
 };
+
+export const deleteMessage = (id, conversant, author) => {
+  if (conversant) {
+    return dispatch => {
+      return axios.post('/api/private-chat/delete-message', { id, conversant })
+        .then(res => {
+          socket.emit('private-delete', { author, reciepient: conversant, id });
+          dispatch({
+            type: DELETE_MESSAGE_PRIVATE,
+            payload: {
+              id,
+              reciepient: conversant
+            }
+          });
+        }).catch(err => {
+          dispatch(addFlashMessage('Message could not be deleted.'));
+        });
+      }
+  } else {
+    socket.emit('delete-message', id);
+    return {
+      type: DELETE_MESSAGE,
+      payload: { id }
+    }
+  }
+};
+
+socket.on('broadcast-deletion', id => {
+  store.dispatch({
+    type: DELETE_MESSAGE,
+    payload: { id }
+  });
+});

--- a/src/components/dashboard/Chat/Chat.js
+++ b/src/components/dashboard/Chat/Chat.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactEmoji from 'react-emoji';
-import { Route, NavLink } from 'react-router-dom';
 
 const parseTime = (timestamp) => {
   let a = new Date(timestamp);

--- a/src/components/dashboard/Chat/ChatModal.js
+++ b/src/components/dashboard/Chat/ChatModal.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import React from 'react';
 import { Modal, Button } from 'semantic-ui-react';
 

--- a/src/reducers/chat.js
+++ b/src/reducers/chat.js
@@ -11,6 +11,10 @@ import {
   RECEIVED_LIKE
 } from '../actions/chat';
 
+/*** Chat history is a List. Each entry represents
+ * a message and is a Map, within which likes are
+ * represented as a Set ***/
+
 export default (state = List(), action) => {
   const { type, payload } = action;
 

--- a/src/reducers/privateChat.js
+++ b/src/reducers/privateChat.js
@@ -1,4 +1,4 @@
-
+/* eslint-disable */
 import { List, Map, Set } from 'immutable';
 import {
   POPULATE_PRIVATE,
@@ -7,17 +7,22 @@ import {
   EDIT_MESSAGE_PRIVATE,
   DELETE_MESSAGE_PRIVATE,
   LIKE_MESSAGE_PRIVATE,
-  RECEIVED_LIKE_PRIVATE,
   RECEIVED_MESSAGE_PRIVATE,
+  RECEIVED_LIKE_PRIVATE,
   RECEIVED_UPDATE_PRIVATE,
+  RECEIVED_DELETE_PRIVATE
 } from '../actions/chat';
+
+/*** private chat default state is a map
+ * where keys represent the user being chatted with
+ * which map to a single List of chat history ***/
 
 export default (state = Map(), action) => {
   const { type, payload } = action;
 
   switch (type) {
 
-    case POPULATE_PRIVATE:
+    case POPULATE_PRIVATE: {
       const { user, data } = payload;
       // we basically need to do some conversions to the data...
       data.map(data => {
@@ -33,32 +38,38 @@ export default (state = Map(), action) => {
         m = m.delete('likes');
         return m.set('likes', Set(likes));
       }));
+    }
 
-    case INITIALIZE_PRIVATE:
+    case INITIALIZE_PRIVATE: {
       return state.has(payload) ? state : state.set(payload, List());
+    }
 
-    case ADD_MESSAGE_PRIVATE:
+    case ADD_MESSAGE_PRIVATE: {
       const { reciepient, message } = payload;
       return state.updateIn([reciepient], l => l.push(message));
+    }
 
-    case DELETE_MESSAGE_PRIVATE:
+    case DELETE_MESSAGE_PRIVATE: {
       return state.updateIn([payload.reciepient], l =>
         l.filter(message => message.get('id') !== payload.id));
+    }
 
-    case EDIT_MESSAGE_PRIVATE:
-      return state.updateIn([payload.reciepient], l => {
+    case EDIT_MESSAGE_PRIVATE: {
+      const { id, text, reciepient } = payload;
+      return state.updateIn([reciepient], l => {
         return l.map(message => {
-          if (message.get('id') === payload.id) {
-            return message.set('text', payload.text);
+          if (message.get('id') === id) {
+            return message.set('text', text);
           } else {
             return message;
           }
         });
       });
+    }
 
-    case LIKE_MESSAGE_PRIVATE:
-      const { messageId, liker } = payload;
-      return state.updateIn([payload.reciepient], l => {
+    case LIKE_MESSAGE_PRIVATE: {
+      const { messageId, liker, reciepient } = payload;
+      return state.updateIn([reciepient], l => {
         return l.map(message => {
           if (message.get('id') === messageId && !message.get('likes').has(liker)) {
               return message.update('likes', likes => likes.add(liker))
@@ -67,30 +78,49 @@ export default (state = Map(), action) => {
           }
         });
       });
+    }
 
-    case RECEIVED_LIKE_PRIVATE:
-    // needs to be updated for private chat
-      return state.map(message => {
-        if (message.get('id') === payload.messageId) {
-          return message.update('likes', likes => likes.add(payload.liker));
-        } else {
-          return message;
-        }
+    // real-time update actions:
+
+    case RECEIVED_MESSAGE_PRIVATE: {
+      const { author, reciepient, message } = payload;
+      return state.updateIn([reciepient], l => l.push(Map(message)));
+    }
+
+    case RECEIVED_UPDATE_PRIVATE: {
+      const { author, reciepient, id, text } = payload;
+      return state.updateIn([reciepient], l => {
+        return l.map(message => {
+          if (message.get('id') === id) {
+            return message.set('text', text);
+          } else {
+            return message;
+          }
+        });
       });
+    }
 
-    case RECEIVED_MESSAGE_PRIVATE:
-    // needs to be updated for private chat
-      return state.push(Map(action.payload));
-
-    case RECEIVED_UPDATE_PRIVATE:
-    // needs to be updated for private chat
-      return state.map(message => {
-        if (message.get('id') === payload.id) {
-          return Map(payload);
-        } else {
-          return message;
-        }
+    case RECEIVED_LIKE_PRIVATE: {
+      const { liker, reciepient, id } = payload;
+      return state.updateIn([reciepient], l => {
+        return l.map(message => {
+          if (message.get('id') === payload.messageId) {
+            return message.update('likes', likes => likes.add(liker));
+          } else {
+            return message;
+          }
+        });
       });
+    }
+
+    case RECEIVED_DELETE_PRIVATE: {
+      const { author, reciepient, id } = payload;
+      return state.updateIn([reciepient], l => {
+        return l.filter(m => {
+          return m.get('id') !== id;
+        });
+      });
+    }
 
     default: return state;
   }

--- a/src/styles/components/_Dashboard.scss
+++ b/src/styles/components/_Dashboard.scss
@@ -59,6 +59,43 @@
     color: rgb(0,225,225) !important;
     transition: color 250ms ease-in-out;
   }
+  #privateChatIcon {
+    position: absolute;
+    font-size: 22px;
+    right: 32px;
+    top: 9px;
+    transition: color 250ms ease-in-out;
+  }
+  #privateChatIcon:hover {
+    cursor: pointer;
+    color: rgb(0,225,225) !important;
+    transition: color 250ms ease-in-out;
+  }
+  #privateChatChannels {
+    position: absolute;
+    top: 5px;
+    right: 65px;
+    width: 225px;
+    min-height: 35px;
+    padding: 10px;
+    color: black;
+    border-radius: 3px;
+    background: rgba(0,225,225, 0.65);
+    h3 {
+      text-decoration: underline;
+      margin-bottom: 7px;
+    }
+    .privateChannel {
+      font-weight: bold;
+      color: black;
+      transition: color 150ms ease-in-out;
+    }
+    .privateChannel:hover {
+      cursor: pointer;
+      color: white;
+      transition: color 150ms ease-in-out;
+    }
+  }
   #chatInput {
     padding-right: 35px;
   }


### PR DESCRIPTION
**Version 1 of fully implemented private chat:** [**Demo**](http://recordit.co/xfviQrtqjU)

- Private chat history is persisted to the database.
- The main chat component now renders a list of private chat channels per user.
- Private chat supports these events: add message, delete message, edit message, like message (same events for main chat).
- All chat actions emit real-time updates via web sockets which will register on connected clients. The process is like this:

1. Original client submits an event in a private chat.
2. If this event is successfully updated in the database, the original client UI + state update (database is single source of truth).
3. The original client emits a real-time update via socket.io to other connected clients.
4. These clients receive socket events and update accordingly.

These features need to be verified against multiple users because in testing I have to keep logging in as the same user in different browser windows.

This is probably not very scaleable because right now all connected clients will receive a socket event for private messages regardless of if the messages are intended for them or not. But it's a start.