### PR TITLE
improvements to chat

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
     "lodash": "^4.17.4",
     "node-sass": "^4.5.0",
     "npm-run-all": "^4.0.2",
+    "prop-types": "^15.5.4",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-emoji": "^0.4.4",

--- a/client/src/actions/onlineStatus.js
+++ b/client/src/actions/onlineStatus.js
@@ -4,13 +4,19 @@ import { store } from '../index';
 export const POPULATE_ONLINE_USERS = 'POPULATE_ONLINE_USERS';
 export const USER_ONLINE = 'USER_ONLINE';
 export const USER_OFFLINE = 'USER_OFFLINE';
-
-socket.on('connect', () => socket.emit('user-online', { user: store.getState().user.username }));
+export const NEW_USER_JOINED = 'NEW_USER_JOINED';
 
 socket.on('populate-online-users', ({ users }) => {
   store.dispatch({
     type: POPULATE_ONLINE_USERS,
     payload: Object.keys(users)
+  });
+});
+
+socket.on('new-user-joined', ({ user }) => {
+  store.dispatch({
+    type: NEW_USER_JOINED,
+    payload: user
   });
 });
 

--- a/client/src/components/AppContainer.js
+++ b/client/src/components/AppContainer.js
@@ -1,6 +1,8 @@
 import React from 'react';
+import propTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Route } from 'react-router-dom';
+import { socket } from '../actions/chat';
 import { populateCommunity } from '../actions/community';
 import { populateChat, fetchPrivateChat } from '../actions/chat';
 import { saveUser, getUserData, logoutUser } from '../actions/user';
@@ -20,9 +22,13 @@ class AppContainer extends React.Component {
       if (user) {
         // fetch user, community, and chat data when dashboard loads:
         this.props.saveUser(user);
+        // only fetch chat and community if none exists
         if (!this.props.community) this.props.populateCommunity();
         if (!this.props.chat) this.props.populateChat();
         this.props.fetchPrivateChat(user.username);
+
+        // announce this user is now online, should refresh status if user reloads page:
+        socket.emit('user-online', { user: user.username });
 
       } else {
         this.props.logoutUser();
@@ -77,12 +83,12 @@ class AppContainer extends React.Component {
 };
 
 AppContainer.propTypes = {
-  saveUser: React.PropTypes.func.isRequired,
-  username: React.PropTypes.string.isRequired,
-  populateChat: React.PropTypes.func.isRequired,
-  addFlashMessage: React.PropTypes.func.isRequired,
-  clearFlashMessage: React.PropTypes.func.isRequired,
-  populateCommunity: React.PropTypes.func.isRequired,
+  saveUser: propTypes.func.isRequired,
+  username: propTypes.string.isRequired,
+  populateChat: propTypes.func.isRequired,
+  addFlashMessage: propTypes.func.isRequired,
+  clearFlashMessage: propTypes.func.isRequired,
+  populateCommunity: propTypes.func.isRequired,
 }
 
 const mapStateToProps = (state) => {

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 import { NavLink } from 'react-router-dom';
@@ -71,8 +72,8 @@ const mapStateToProps = (state) => {
 }
 
 NavBar.propTypes = {
-  user: React.PropTypes.object.isRequired,
-  screen: React.PropTypes.object.isRequired
+  user: propTypes.object.isRequired,
+  screen: propTypes.object.isRequired
 }
 
 export const mapScreenSizeToProps = (screenSize) => {

--- a/client/src/components/common/DividingHeader.js
+++ b/client/src/components/common/DividingHeader.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import propTypes from 'prop-types';
 
 /*
-TODO: 
+TODO:
   - Make this use Semantics "dividing header" class instead
   - allow for passing in which size as props
   - this will make component more reusable and robust
@@ -57,8 +58,8 @@ const DividingHeader = ({ icon, content, size }) => {
 }
 
 DividingHeader.propTypes = {
-  content: React.PropTypes.string.isRequired,
-  icon: React.PropTypes.string
+  content: propTypes.string.isRequired,
+  icon: propTypes.string
 }
 
 DividingHeader.defaultProps = {

--- a/client/src/components/common/DropdownMulti.js
+++ b/client/src/components/common/DropdownMulti.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 import { Dropdown } from 'semantic-ui-react';
 
 const DropdownMulti = (props) => (
@@ -9,13 +10,13 @@ const DropdownMulti = (props) => (
 );
 
 DropdownMulti.propTypes = {
-  options: React.PropTypes.array.isRequired,
-  onChange: React.PropTypes.func.isRequired,
-  placeholder: React.PropTypes.string,
-  search: React.PropTypes.bool,
-  noResultsMessage: React.PropTypes.string,
-  fluid: React.PropTypes.bool,
-  value: React.PropTypes.array.isRequired
+  options: propTypes.array.isRequired,
+  onChange: propTypes.func.isRequired,
+  placeholder: propTypes.string,
+  search: propTypes.bool,
+  noResultsMessage: propTypes.string,
+  fluid: propTypes.bool,
+  value: propTypes.array.isRequired
 }
 
 DropdownMulti.defaultProps = {

--- a/client/src/components/common/FormField.js
+++ b/client/src/components/common/FormField.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 
 const FormField = ({
   icon,
@@ -64,20 +65,20 @@ const FormField = ({
 }
 
 FormField.propTypes = {
-  icon: React.PropTypes.string,
-  type: React.PropTypes.string,
-  label: React.PropTypes.string,
-  disabled: React.PropTypes.bool,
-  onChange: React.PropTypes.func,
-  tooltip: React.PropTypes.string,
-  actionUrl: React.PropTypes.string,
-  actionIcon: React.PropTypes.object,
-  placeholder: React.PropTypes.string,
-  inputOptions: React.PropTypes.string,
-  reactionIcon: React.PropTypes.object,
-  name: React.PropTypes.string.isRequired,
-  value: React.PropTypes.string.isRequired,
-  errors: React.PropTypes.object.isRequired
+  icon: propTypes.string,
+  type: propTypes.string,
+  label: propTypes.string,
+  disabled: propTypes.bool,
+  onChange: propTypes.func,
+  tooltip: propTypes.string,
+  actionUrl: propTypes.string,
+  actionIcon: propTypes.object,
+  placeholder: propTypes.string,
+  inputOptions: propTypes.string,
+  reactionIcon: propTypes.object,
+  name: propTypes.string.isRequired,
+  value: propTypes.string.isRequired,
+  errors: propTypes.object.isRequired
 }
 
 FormField.defaultProps = {

--- a/client/src/components/common/ListItem.js
+++ b/client/src/components/common/ListItem.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 
 const ListItem = ({ icon, children }) => {
   return (
@@ -12,8 +13,8 @@ const ListItem = ({ icon, children }) => {
 }
 
 ListItem.propTypes = {
-  icon: React.PropTypes.string,
-  children: React.PropTypes.node.isRequired
+  icon: propTypes.string,
+  children: propTypes.node.isRequired
 }
 
 ListItem.defaultProps = {

--- a/client/src/components/common/MessageBox.js
+++ b/client/src/components/common/MessageBox.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 
 class MessageBox extends React.Component {
   state = {
@@ -25,9 +26,9 @@ class MessageBox extends React.Component {
 }
 
 MessageBox.propTypes = {
-  header: React.PropTypes.string,
-  message: React.PropTypes.string.isRequired,
-  color: React.PropTypes.string
+  header: propTypes.string,
+  message: propTypes.string.isRequired,
+  color: propTypes.string
 }
 
 MessageBox.defaultProps = {

--- a/client/src/components/common/RadioButton.js
+++ b/client/src/components/common/RadioButton.js
@@ -1,14 +1,15 @@
 import React from 'react';
+import propTypes from 'prop-types';
 
 const RadioButton = ({ onChange, name, label, checked }) => {
   return (
     <div>
       <div className="field">
         <div className="ui radio checkbox">
-          <input 
-            onChange={onChange} 
-            type="radio" 
-            id={label.replace(/\s/g, '_')} 
+          <input
+            onChange={onChange}
+            type="radio"
+            id={label.replace(/\s/g, '_')}
             name={name}
             checked={checked} />
           <label>{label}</label>
@@ -19,10 +20,10 @@ const RadioButton = ({ onChange, name, label, checked }) => {
 }
 
 RadioButton.propTypes = {
-  onChange: React.PropTypes.func.isRequired,
-  name: React.PropTypes.string.isRequired,
-  label: React.PropTypes.string,
-  checked: React.PropTypes.bool.isRequired
+  onChange: propTypes.func.isRequired,
+  name: propTypes.string.isRequired,
+  label: propTypes.string,
+  checked: propTypes.bool.isRequired
 }
 
 export default RadioButton;

--- a/client/src/components/common/RepoList.js
+++ b/client/src/components/common/RepoList.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 import isEmpty from 'lodash/isEmpty';
 import { repoOptions } from '../../assets/data/dropdownOptions';
 import { Dropdown, Input } from 'semantic-ui-react';
@@ -333,10 +334,10 @@ class RepoList extends React.Component {
 }
 
 RepoList.propTypes = {
-  prePopulateList: React.PropTypes.array,
-  username: React.PropTypes.string.isRequired,
-  saveChanges: React.PropTypes.func.isRequired,
-  saveListToParent: React.PropTypes.func.isRequired,
+  prePopulateList: propTypes.array,
+  username: propTypes.string.isRequired,
+  saveChanges: propTypes.func.isRequired,
+  saveListToParent: propTypes.func.isRequired,
 }
 
 RepoList.defaultProps = {

--- a/client/src/components/common/SliderToggle.js
+++ b/client/src/components/common/SliderToggle.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 
 const ON_POSITION = { left: 43 };
 const OFF_POSITION = { left: 3 };
@@ -38,9 +39,9 @@ class SliderToggle extends React.Component {
 }
 
 SliderToggle.propTypes = {
-  saveStateToParent: React.PropTypes.func.isRequired,
-  label: React.PropTypes.string,
-  defaultOn: React.PropTypes.bool.isRequired
+  saveStateToParent: propTypes.func.isRequired,
+  label: propTypes.string,
+  defaultOn: propTypes.bool.isRequired
 }
 
 export default SliderToggle;

--- a/client/src/components/common/UserLabel.js
+++ b/client/src/components/common/UserLabel.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 
 const UserLabel = ({ color, size, image, username, label, folder, toggleAll, showAvatar }) => {
   if (!image) {
@@ -22,16 +23,16 @@ const UserLabel = ({ color, size, image, username, label, folder, toggleAll, sho
 }
 
 UserLabel.propTypes = {
-  size: React.PropTypes.string,
-  label: React.PropTypes.string,
-  color: React.PropTypes.string,
-  toggleAll: React.PropTypes.func,
-  showAvatar: React.PropTypes.bool,
-  image: React.PropTypes.string,
-  username: React.PropTypes.string.isRequired,
-  folder: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.bool
+  size: propTypes.string,
+  label: propTypes.string,
+  color: propTypes.string,
+  toggleAll: propTypes.func,
+  showAvatar: propTypes.bool,
+  image: propTypes.string,
+  username: propTypes.string.isRequired,
+  folder: propTypes.oneOfType([
+    propTypes.string,
+    propTypes.bool
   ])
 }
 

--- a/client/src/components/dashboard/Chat/ChatController.js
+++ b/client/src/components/dashboard/Chat/ChatController.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import React from 'react';
+import propTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Route, NavLink } from 'react-router-dom';
 import { connectScreenSize } from 'react-screen-size';
@@ -242,16 +243,16 @@ class ChatController extends React.Component {
 };
 
 ChatController.propTypes = {
-  user: React.PropTypes.object.isRequired,
-  chat: React.PropTypes.object.isRequired,
-  addMessage: React.PropTypes.func.isRequired,
-  saveEdit: React.PropTypes.func.isRequired,
-  likeMessage: React.PropTypes.func.isRequired,
-  deleteMessage: React.PropTypes.func.isRequired,
-  broadcastEdit: React.PropTypes.func.isRequired,
-  clearNotifications: React.PropTypes.func.isRequired,
-  mentors: React.PropTypes.object.isRequired,
-  onlineStatus: React.PropTypes.object.isRequired
+  user: propTypes.object.isRequired,
+  chat: propTypes.object.isRequired,
+  addMessage: propTypes.func.isRequired,
+  saveEdit: propTypes.func.isRequired,
+  likeMessage: propTypes.func.isRequired,
+  deleteMessage: propTypes.func.isRequired,
+  broadcastEdit: propTypes.func.isRequired,
+  clearNotifications: propTypes.func.isRequired,
+  mentors: propTypes.object.isRequired,
+  onlineStatus: propTypes.object.isRequired
 };
 
 export const findMentors = (community) => {

--- a/client/src/components/dashboard/Chat/EmojiInput.js
+++ b/client/src/components/dashboard/Chat/EmojiInput.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 import EmojiPicker from 'react-emoji-picker';
 import emojiMap from 'react-emoji-picker/lib/emojiMap';
 
@@ -109,7 +110,7 @@ export default class Emoji extends React.Component {
 };
 
 Emoji.propTypes = {
-  screen: React.PropTypes.object.isRequired,
-  submit: React.PropTypes.func.isRequired,
-  placeholder: React.PropTypes.string.isRequired
+  screen: propTypes.object.isRequired,
+  submit: propTypes.func.isRequired,
+  placeholder: propTypes.string.isRequired
 }

--- a/client/src/components/dashboard/Community/CertLinks.js
+++ b/client/src/components/dashboard/Community/CertLinks.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 import { Icon } from './SocialLinks';
 
 const URL = "https://freeCodeCamp.com/";
@@ -34,8 +35,8 @@ const CertLinks = ({ handleClick, fccCerts, username }) => {
 }
 
 CertLinks.propTypes = {
-  fccCerts: React.PropTypes.object.isRequired,
-  username: React.PropTypes.string.isRequired
+  fccCerts: propTypes.object.isRequired,
+  username: propTypes.string.isRequired
 }
 
 export default CertLinks;

--- a/client/src/components/dashboard/Mentorship/SearchFilters.js
+++ b/client/src/components/dashboard/Mentorship/SearchFilters.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 import { Checkbox } from 'semantic-ui-react';
 
 const Filters = ({ filterOptions, handleChange, state }) => {
@@ -24,9 +25,9 @@ const Filters = ({ filterOptions, handleChange, state }) => {
 }
 
 Filters.propTypes = {
-  state: React.PropTypes.object.isRequired,
-  handleChange: React.PropTypes.func.isRequired,
-  filterOptions: React.PropTypes.array.isRequired
+  state: propTypes.object.isRequired,
+  handleChange: propTypes.func.isRequired,
+  filterOptions: propTypes.array.isRequired
 }
 
 export default Filters;

--- a/client/src/components/dashboard/Mentorship/SearchResults.js
+++ b/client/src/components/dashboard/Mentorship/SearchResults.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 import styled from 'styled-components';
 import {
   ThickPaddedBottom,
@@ -64,10 +65,10 @@ const SearchResults = ({ initiatePrivateChat, currentUser, results, noResults })
 }
 
 SearchResults.propTypes = {
-  initiatePrivateChat: React.PropTypes.func.isRequired,
-  currentUser: React.PropTypes.string.isRequired,
-  results: React.PropTypes.array.isRequired,
-  noResults: React.PropTypes.bool.isRequired
+  initiatePrivateChat: propTypes.func.isRequired,
+  currentUser: propTypes.string.isRequired,
+  results: propTypes.array.isRequired,
+  noResults: propTypes.bool.isRequired
 }
 
 export default SearchResults;

--- a/client/src/components/dashboard/Profile/Mentorship.js
+++ b/client/src/components/dashboard/Profile/Mentorship.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 import Ribbon from './common/RibbonHeader';
 import MessageBox from '../../common/MessageBox';
 import SliderToggle from '../../common/SliderToggle';
@@ -52,15 +53,15 @@ const Mentorship = ({
 }
 
 Mentorship.propTypes = {
-  error: React.PropTypes.string,
-  toggle: React.PropTypes.func.isRequired,
-  isMentor: React.PropTypes.bool.isRequired,
-  showPopUp: React.PropTypes.bool.isRequired,
-  subSaveClick: React.PropTypes.func.isRequired,
-  showMentorship: React.PropTypes.bool.isRequired,
-  toggleMentorship: React.PropTypes.func.isRequired,
-  handleInputChange: React.PropTypes.func.isRequired,
-  mentorshipSkills: React.PropTypes.string.isRequired,
+  error: propTypes.string,
+  toggle: propTypes.func.isRequired,
+  isMentor: propTypes.bool.isRequired,
+  showPopUp: propTypes.bool.isRequired,
+  subSaveClick: propTypes.func.isRequired,
+  showMentorship: propTypes.bool.isRequired,
+  toggleMentorship: propTypes.func.isRequired,
+  handleInputChange: propTypes.func.isRequired,
+  mentorshipSkills: propTypes.string.isRequired,
 }
 
 Mentorship.defaultProps = {

--- a/client/src/components/dashboard/Profile/Public/FCCTables.js
+++ b/client/src/components/dashboard/Profile/Public/FCCTables.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 import Table from './Table';
 import styled from 'styled-components';
 import TableRow from './TableRow';
@@ -87,12 +88,12 @@ const FccTables = ({
 }
 
 FccTables.propTypes = {
-  fccCerts: React.PropTypes.object.isRequired,
-  longestStreak: React.PropTypes.string.isRequired,
-  currentStreak: React.PropTypes.string.isRequired,
-  browniePoints: React.PropTypes.string.isRequired,
-  firstChallenge: React.PropTypes.string.isRequired,
-  totalChallneges: React.PropTypes.number.isRequired,
+  fccCerts: propTypes.object.isRequired,
+  longestStreak: propTypes.string.isRequired,
+  currentStreak: propTypes.string.isRequired,
+  browniePoints: propTypes.string.isRequired,
+  firstChallenge: propTypes.string.isRequired,
+  totalChallneges: propTypes.number.isRequired,
 }
 
 export default FccTables;

--- a/client/src/components/dashboard/Profile/Public/LocationSteps.js
+++ b/client/src/components/dashboard/Profile/Public/LocationSteps.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 import styled from 'styled-components';
 import {
   CenterAlignedWrapper
@@ -46,7 +47,7 @@ const Steps = ({ personal }) => {
 }
 
 Steps.propTypes = {
-  personal: React.PropTypes.object.isRequired
+  personal: propTypes.object.isRequired
 }
 
 export default Steps;

--- a/client/src/components/dashboard/Profile/Public/SocialList.js
+++ b/client/src/components/dashboard/Profile/Public/SocialList.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 import styled from 'styled-components';
 import { hoverTransition } from '../../../../styles/globalStyles';
 
@@ -66,9 +67,9 @@ const SocialList = ({ profileUrl, username, social }) => {
 }
 
 SocialList.propTypes = {
-  social: React.PropTypes.object.isRequired,
-  username: React.PropTypes.string.isRequired,
-  profileUrl: React.PropTypes.string.isRequired,
+  social: propTypes.object.isRequired,
+  username: propTypes.string.isRequired,
+  profileUrl: propTypes.string.isRequired,
 }
 
 export default SocialList;

--- a/client/src/components/dashboard/Profile/Public/TableRow.js
+++ b/client/src/components/dashboard/Profile/Public/TableRow.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 
 const TableRow = ({ icon, content, header }) => {
   return(
@@ -17,16 +18,16 @@ const TableRow = ({ icon, content, header }) => {
 }
 
 TableRow.propTypes = {
-  icon: React.PropTypes.string.isRequired,
-  header: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.element,
+  icon: propTypes.string.isRequired,
+  header: propTypes.oneOfType([
+    propTypes.string,
+    propTypes.element,
   ]),
-  content: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.object,
-    React.PropTypes.element,
-    React.PropTypes.number,
+  content: propTypes.oneOfType([
+    propTypes.string,
+    propTypes.object,
+    propTypes.element,
+    propTypes.number,
   ])
 }
 

--- a/client/src/components/dashboard/Profile/common/RibbonHeader.js
+++ b/client/src/components/dashboard/Profile/common/RibbonHeader.js
@@ -1,12 +1,13 @@
 import React from 'react';
+import propTypes from 'prop-types';
 
 const RibbonHeader = ({ content, onClick, wrapperClass, showPopUp, subSaveClick, id, showSave }) => {
   return(
     <div>
       <div className={`ui green large ribbon label ${wrapperClass}`} onClick={onClick}>
         {content}
-        { 
-          showSave && 
+        {
+          showSave &&
           <div className="detail">
             <i onClick={subSaveClick} id={id} className="saveSection save icon" />
           </div>
@@ -18,10 +19,10 @@ const RibbonHeader = ({ content, onClick, wrapperClass, showPopUp, subSaveClick,
 }
 
 RibbonHeader.propTypes = {
-  content: React.PropTypes.string.isRequired,
-  onClick: React.PropTypes.func.isRequired,
-  wrapperClass: React.PropTypes.string.isRequired,
-  showSave: React.PropTypes.bool.isRequired
+  content: propTypes.string.isRequired,
+  onClick: propTypes.func.isRequired,
+  wrapperClass: propTypes.string.isRequired,
+  showSave: propTypes.bool.isRequired
 }
 
 export default RibbonHeader;

--- a/client/src/components/dashboard/Profile_Config.js
+++ b/client/src/components/dashboard/Profile_Config.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import React from 'react';
+import propTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Social from './Profile/Social';
 import UserLabel from '../common/UserLabel';
@@ -379,8 +380,8 @@ const mapStateToProps = (state) => {
 }
 
 Profile.propTypes = {
-  user: React.PropTypes.object.isRequired,
-  viewState: React.PropTypes.object
+  user: propTypes.object.isRequired,
+  viewState: propTypes.object
 }
 
 export default connect(mapStateToProps, { saveUser, savePreferencesViewState })(Profile);

--- a/client/src/components/dashboard/Profile_Public.js
+++ b/client/src/components/dashboard/Profile_Public.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 import { connect } from 'react-redux';
 import UserLabel from '../common/UserLabel';
 import LocationSteps from './Profile/Public/LocationSteps';
@@ -224,7 +225,7 @@ class PublicProfile extends React.Component {
 }
 
 PublicProfile.propTypes = {
-  user: React.PropTypes.object.isRequired
+  user: propTypes.object.isRequired
 }
 
 const findUser = (community, username) => {

--- a/client/src/components/flash/FlashMessage.js
+++ b/client/src/components/flash/FlashMessage.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 
 class FlashMessage extends React.Component {
 
@@ -23,8 +24,8 @@ class FlashMessage extends React.Component {
 }
 
 FlashMessage.propTypes = {
-  message: React.PropTypes.object.isRequired,
-  deleteFlashMessage: React.PropTypes.func.isRequired
+  message: propTypes.object.isRequired,
+  deleteFlashMessage: propTypes.func.isRequired
 }
 
 export default FlashMessage;

--- a/client/src/components/flash/FlashMessagesList.js
+++ b/client/src/components/flash/FlashMessagesList.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 import FlashMessage from './FlashMessage';
 import { connect } from 'react-redux';
 import { deleteFlashMessage } from '../../actions/flashMessages';
@@ -6,7 +7,7 @@ import { deleteFlashMessage } from '../../actions/flashMessages';
 class FlashMessagesList extends React.Component {
   render() {
     const { deleteFlashMessage } = this.props;
-    const messages = this.props.messages.map(message => 
+    const messages = this.props.messages.map(message =>
       <FlashMessage key={message.id} message={message} deleteFlashMessage={deleteFlashMessage}/>
     );
     return (
@@ -16,13 +17,13 @@ class FlashMessagesList extends React.Component {
 }
 
 FlashMessagesList.propTypes = {
-  messages: React.PropTypes.array.isRequired,
-  deleteFlashMessage: React.PropTypes.func.isRequired
+  messages: propTypes.array.isRequired,
+  deleteFlashMessage: propTypes.func.isRequired
 }
 
 const mapStateToProps = (state) => {
   return {
-    messages: state.flashMessages 
+    messages: state.flashMessages
   }
 }
 

--- a/client/src/components/signup/PassportPage.js
+++ b/client/src/components/signup/PassportPage.js
@@ -1,7 +1,9 @@
 import React from 'react';
+import propTypes from 'prop-types';
 import { getUserData, verifyUser, saveUser } from '../../actions/user';
 import { addFlashMessage } from '../../actions/flashMessages';
 import { connect } from 'react-redux';
+import { socket } from '../../actions/chat';
 
 class PassportPage extends React.Component {
   state = {
@@ -57,6 +59,7 @@ class PassportPage extends React.Component {
           message: 'Your account is now verified!'
         }
       });
+      socket.emit('announce-new-user', { user });
       this.props.history.push('/dashboard/preferences');
     })
     .catch(err => {
@@ -121,8 +124,8 @@ class PassportPage extends React.Component {
 }
 
 PassportPage.propTypes = {
-  saveUser: React.PropTypes.func.isRequired,
-  addFlashMessage: React.PropTypes.func.isRequired
+  saveUser: propTypes.func.isRequired,
+  addFlashMessage: propTypes.func.isRequired
 }
 
 export default connect(null, { saveUser, addFlashMessage })(PassportPage);

--- a/client/src/reducers/community.js
+++ b/client/src/reducers/community.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 import { SAVE_USER } from '../actions/types';
 import { POPULATE } from '../actions/community';
+import { NEW_USER_JOINED } from '../actions/onlineStatus';
 import { List } from 'immutable';
 
 export default (state = List(), action) => {
@@ -17,6 +18,9 @@ export default (state = List(), action) => {
           return user;
         };
       });
+
+    case NEW_USER_JOINED:
+      return state.concat(action.payload);
 
     default: return state;
   }

--- a/client/src/styles/components/_Chat.scss
+++ b/client/src/styles/components/_Chat.scss
@@ -101,8 +101,8 @@ $lightRed: rgb(255, 109, 88);
       color: black;
       font-size: 22px;
       padding-left: 10px;
-      margin-top: 6px;
-      margin-bottom: 6px;
+      margin-top: 10px;
+      margin-bottom: 10px;
       transition: color 150ms ease-in-out;
       img {
         width: 25px;

--- a/server/chat/chat.js
+++ b/server/chat/chat.js
@@ -48,6 +48,11 @@ module.exports = (io) => {
       }
     });
 
+    // this allows a new user to be added to the community in any connected clients:
+    socket.on('announce-new-user', (user) => {
+      socket.broadcast.emit('new-user-joined', user);
+    });
+
     // global chat:
   	socket.on('submission', (data) => {
       socket.broadcast.emit('broadcast-message', data);


### PR DESCRIPTION
Tries to replace `React.propTypes` with `propTypes` from `prop-types` package... but there is still a console warning? `React.PropTypes` is deprecated at React 15.5 and moved into a separate module.

More importantly, improves chat and adds socket actions which propagate new users joining the community out to any connected clients (to enable initiating a private chat with them) and moves socket action for online status (I think the previous location this status event was being broadcast from may have been contributing to some of the problematic behavior in chat). Together these hope to solve some of the problems currently being seen in chat. Local testing was O.K. again!

Final move with this will probably be migrating the chat flash messages to console logs, or perhaps just telling the user to refresh the page (in the flash message). That might be better, in the event that there is still some error that avoids diagnosis.