### PR TITLE
Applies some fixes in Chat

### DIFF
--- a/client/src/reducers/privateChat.js
+++ b/client/src/reducers/privateChat.js
@@ -26,28 +26,24 @@ export default (state = Map(), action) => {
 
     case POPULATE_PRIVATE: {
       const { user, data } = payload;
-      let recipient;
+      let recipient, likes;
 
       if (data.length === 0) return state;
 
-      // we need to convert the JS to our Immutable chat history:
+      /* we need to convert the JS to our Immutable chat history,
+         this is a little messy but works: */
       data.map(data => {
-        if (data.members[0] === user) {
-          data.members.splice(0,1);
-        } else {
-          data.members.splice(1,1);
-        }
-        recipient = data.members[0];
+        recipient = data.members.filter(m => m !== user)[0];
         state = state.set(recipient, Map({
           notifications: data.notifications[user],
           history: List(data.history.map(h => Map(h)))
+        })).updateIn([recipient, 'history'], h => h.map(m => {
+          likes = m.get('likes');
+          m = m.delete('likes');
+          return m.set('likes', Set(likes));
         }));
       });
-      return state.updateIn([recipient, 'history'], h => h.map(m => {
-        const likes = m.get('likes');
-        m = m.delete('likes');
-        return m.set('likes', Set(likes));
-      }));
+      return state;
     }
 
     case INITIALIZE_PRIVATE: {


### PR DESCRIPTION
This fixes a problem associated with multiple private chats. Basically, data from the server was not properly being converted into Immutable private chat history in Redux when there were more than 1 private chats for a user. This also fixes an issue where a user refreshes a private chat route and the component mounts and renders before data has been fetched and returned from the server. The component throws an error from somewhere in the render method when it tries to access data that doesn't exist yet. This would be better solved with proper loading state but here we have a simpler and quicker solution.