### PR TITLE
begin selective rendering, profile work

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
     "lodash": "^4.17.4",
     "node-sass": "^4.5.0",
     "npm-run-all": "^4.0.2",
-    "prop-types": "^15.5.4",
+    "prop-types": "^15.5.6",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-emoji": "^0.4.4",

--- a/client/src/components/dashboard/Community/UserCard.js
+++ b/client/src/components/dashboard/Community/UserCard.js
@@ -49,12 +49,6 @@ class UserCard extends React.Component {
     const { user, screen } = this.props;
     const joinedOn = user.personal.memberSince.split('-').slice(0, 2);
     const prettyDate = convertMonthToString(...joinedOn);
-    var certs = [];
-    for (var cert in user.fccCerts) {
-      if (user.fccCerts[cert]) {
-        certs.push(cert.replace(/_/g, ' '));
-      }
-    }
 
     return (
       <ClickableCard onClick={() => { this.handleClick(user) }} className='ui raised card'>

--- a/client/src/components/dashboard/Profile/Mentorship.js
+++ b/client/src/components/dashboard/Profile/Mentorship.js
@@ -15,6 +15,7 @@ const Mentorship = ({
   showMentorship,
   mentorshipSkills,
   toggleMentorship,
+  toggleMenteeship,
   handleInputChange,
   handleRadioChange,
 }) => {
@@ -36,34 +37,23 @@ const Mentorship = ({
         <SliderToggle
           defaultOn={isMentor ? true : false}
           saveStateToParent={toggleMentorship}
-          label="Sign me up! I want to be a mentor!" />
-        <div className={`ui six wide field mentorshipSkillsPane ${isMentor ? 'show' : 'hide'}`}>
-          <label>Mentorship Skills</label>
+          label="I would like to be a mentor." />
+        <SliderToggle
+          defaultOn={isMentee ? true : false}
+          saveStateToParent={toggleMenteeship}
+          label="I would like to be mentored." />
+        <div className={`ui six wide field mentorshipSkillsPane ${isMentor || isMentee ? 'show' : 'hide'}`}>
+          <label>Mentorship Bio</label>
           <textarea
             rows="3"
             name="mentorshipSkills"
             value={mentorshipSkills}
             onChange={handleInputChange}
-            placeholder="Please provide a short description of the skills you feel comfortable providing mentorship for." />
+            placeholder="Please provide a short description of the skills you feel comfortable providing mentorship for and / or the areas you are looking for mentorship in." />
           { error &&
             <div style={{ marginTop: 10 }} className="ui red basic label">
               {error}
             </div> }
-        </div>
-        <div className={`ui eight wide field mentorshipSkillsPane ${isMentor ? 'hide' : 'show'}`}>
-          <div className="inline fields">
-            <label>Are you open to being mentored by other users?</label>
-            <RadioButton
-              label='Yes'
-              name="isMentee"
-              onChange={handleRadioChange}
-              checked={isMentee && true} />
-            <RadioButton
-              label='No'
-              name="isMentee"
-              onChange={handleRadioChange}
-              checked={!isMentee && true}  />
-          </div>
         </div>
       </form>
     </div>
@@ -78,6 +68,7 @@ Mentorship.propTypes = {
   subSaveClick: propTypes.func.isRequired,
   showMentorship: propTypes.bool.isRequired,
   toggleMentorship: propTypes.func.isRequired,
+  toggleMenteeship: propTypes.func.isRequired,
   handleInputChange: propTypes.func.isRequired,
   mentorshipSkills: propTypes.string.isRequired,
 }

--- a/client/src/components/dashboard/Profile/Public/SkillsRow.js
+++ b/client/src/components/dashboard/Profile/Public/SkillsRow.js
@@ -20,7 +20,7 @@ const LabelDark = styled.div`
   }
 `;
 
-const Header = styled.div`
+export const Header = styled.div`
   background: #939393 !important;
   color: white !important;
   margin-bottom: 5px !important;

--- a/client/src/components/dashboard/Profile/Public/SocialList.js
+++ b/client/src/components/dashboard/Profile/Public/SocialList.js
@@ -1,75 +1,53 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import styled from 'styled-components';
-import { hoverTransition } from '../../../../styles/globalStyles';
+import Item from './SocialListItem';
 
-const SocialIcon = styled.i`
-  font-size: 22px !important;
-  color: black !important;
-  ${ hoverTransition() }
-`;
-
-const FCCIcon = styled.i`
-  font-size: 20px !important;
-  color: black !important;
-  padding: 0 .75em 0 0 !important;
-  vertical-align: middle !important;
-  ${ hoverTransition() }
-`;
-
-const InlineContent = styled.div`
-  display: inline-block !important;
-`;
-
-const SocialList = ({ profileUrl, username, social }) => {
+const SocialList = ({ profileUrl, username, social, email, contactsOnly }) => {
   return (
-    <div className="ui center aligned segment">
-      <div className="ui relaxed horizontal list">
-        <a href={`https://freeCodeCamp.com/${username}`} target="_blank" className="item">
-          <FCCIcon className="fa fa-free-code-camp" />
-          <InlineContent className="content">
-            <div className="header">freeCodeCamp</div>
-          </InlineContent>
-        </a>
-        <a href={profileUrl} target="_blank" className="item">
-          <SocialIcon className="github icon" />
-          <div className="content">
-            <div className="header">GitHub</div>
-          </div>
-        </a>
-        { social.codepen &&
-          <a href={`https://codepen.io/${social.codepen}`} target="_blank" className="item">
-            <SocialIcon className="codepen icon" />
-            <div className="content">
-              <div className="header">Codepen</div>
-            </div>
-          </a> }
-        { social.twitter &&
-          <a href={`https://twitter.com/${social.twitter}`} target="_blank" className="item">
-          <SocialIcon className="twitter icon" />
-          <div className="content">
-            <div className="header">Twitter</div>
-          </div>
-          </a> }
-        { social.linkedin &&
-          <a
-          target="_blank"
-          className="item"
-          href={`https://www.linkedin.com/search/results/index/?keywords=${encodeURIComponent(social.linkedin)}&origin=GLOBAL_SEARCH_HEADER`}>
-          <SocialIcon className="linkedin icon" />
-          <div className="content">
-            <div className="header">LinkedIn</div>
-          </div>
-        </a> }
-      </div>
+    <div className="ui relaxed horizontal list">
+    { email &&
+      <Item
+        icon="mail"
+        text={email}
+        href={`mailto:${email}?subject=fCC%20Alumni%20Network%20/%20Contact%20Request`} /> }
+    { !contactsOnly &&
+      <Item
+        icon="fcc"
+        text="freeCodeCamp"
+        href={`https://freeCodeCamp.com/${username}`} /> }
+      <Item
+        icon="github"
+        href={profileUrl}
+        text="GitHub" />
+    { social.codepen && !contactsOnly &&
+      <Item
+        icon="codepen"
+        text="Codepen"
+        href={`https://codepen.io/${social.codepen}`} /> }
+    { social.twitter &&
+      <Item
+        icon="twitter"
+        text="Twitter"
+        href={`https://twitter.com/${social.twitter}`} /> }
+    { social.linkedin &&
+      <Item
+        icon="linkedin"
+        text="LinkedIn"
+        href={`https://www.linkedin.com/search/results/index/?keywords=${encodeURIComponent(social.linkedin)}&origin=GLOBAL_SEARCH_HEADER`} /> }
     </div>
   );
 }
 
 SocialList.propTypes = {
+  email: propTypes.string,
+  contactsOnly: propTypes.bool,
   social: propTypes.object.isRequired,
   username: propTypes.string.isRequired,
   profileUrl: propTypes.string.isRequired,
+}
+
+SocialList.defaultProps = {
+  contactsOnly: false
 }
 
 export default SocialList;

--- a/client/src/components/dashboard/Profile/Public/SocialListItem.js
+++ b/client/src/components/dashboard/Profile/Public/SocialListItem.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import styled from 'styled-components';
+import { hoverTransition } from '../../../../styles/globalStyles';
+
+export const SocialIcon = styled.i`
+  font-size: 22px !important;
+  color: black !important;
+  ${ hoverTransition() }
+`;
+
+const FCCIcon = styled.i`
+font-size: 20px !important;
+color: black !important;
+padding: 0 .75em 0 0 !important;
+vertical-align: middle !important;
+${ hoverTransition() }
+`;
+
+const InlineContent = styled.div`
+  display: inline-block !important;
+`;
+
+const SocialListItem = ({ href, icon, text }) => {
+  return (
+    <a href={href} className="item">
+      { icon === 'fcc'
+        ? <FCCIcon className="fa fa-free-code-camp" />
+        : <SocialIcon className={`${icon} icon`} /> }
+      <InlineContent className="content">
+        <div className="header">{text}</div>
+      </InlineContent>
+    </a>
+  );
+}
+
+export default SocialListItem;

--- a/client/src/components/dashboard/Profile_Config.js
+++ b/client/src/components/dashboard/Profile_Config.js
@@ -19,15 +19,17 @@ import Validator from 'validator';
 
 /*
 TODO:
-  - MENTORSHIP: Looking for mentorship? If so, in what? Add new sliderToggle and textarea to accomodate - would need to modify user model
+  - MENTORSHIP / VALIDATION: Require mentorship bio if either slider is toggled!
   - MENTORSHIP: Revisit copy! Some of this info should be moved to the "about us" public page.
-  - we need to look at how users enter location (should have zip code or somehting and get location name by API - for D3 map as well!)
+  - PERSONAL: Add info icon to email field, saying email will be publicly displayed if you provide it
   - add title and description fields for sharing repos
   - add error popup and modal for error on save
   - folder icon behavior - open when any field expanded
   - add validations for form fields - should be loose validations since nothing is strictly required
-  - use passport to pull in LinkedIn and Twitter handles
   - error handling if save to server fails?
+  - use passport to pull in LinkedIn and Twitter handles √
+  - we need to look at how users enter location (should have zip code or somehting and get location name by API - for D3 map as well!) √
+  - MENTORSHIP: Looking for mentorship? If so, in what? Add new sliderToggle √
   - save individual section √
   - save all √
   - connect to DB √
@@ -86,6 +88,12 @@ class Profile extends React.Component {
     this.setState({ user });
   }
 
+  toggleMenteeship = (bool) => {
+    var { user } = this.state;
+    user.mentorship.isMentee = bool;
+    this.setState({ user });
+  }
+
   handleSkillsChange = (e, data) => {
     var { user } = this.state;
     user.skillsAndInterests.coreSkills = data.value;
@@ -126,10 +134,6 @@ class Profile extends React.Component {
 
     if (e.target.name === 'jobSearch') {
       user.career.jobSearch = e.target.id.replace(/_/g, ' ');
-    }
-
-    if (e.target.name === 'isMentee') {
-      user.mentorship.isMentee = e.target.id === 'Yes' ? true : false;
     }
 
     this.setState({ user });
@@ -185,12 +189,12 @@ class Profile extends React.Component {
       }
     }
     if (field === 'mentorshipSkills') {
-      if (Validator.isLength(str, { min: 0, max: 165 })) {
+      if (Validator.isLength(str, { min: 0, max: 200 })) {
         errors.mentorshipSkills = '';
         this.setState({ errors });
         return true;
       } else {
-        errors.mentorshipSkills = "Mentorshio bio must be 150 characters or less."
+        errors.mentorshipSkills = "Mentorshio bio must be 200 characters or less."
         this.setState({ errors });
         return false;
       }
@@ -329,6 +333,7 @@ class Profile extends React.Component {
             subSaveClick={this.handleSubSaveClick}
             showPopUp={this.state.mentorshipPopUp}
             toggleMentorship={this.toggleMentorship}
+            toggleMenteeship={this.toggleMenteeship}
             handleInputChange={this.handleInputChange}
             handleRadioChange={this.handleRadioChange}
             showMentorship={this.state.viewState.showMentorship} />

--- a/client/src/components/dashboard/Profile_Public.js
+++ b/client/src/components/dashboard/Profile_Public.js
@@ -2,10 +2,12 @@ import React from 'react';
 import propTypes from 'prop-types';
 import { connect } from 'react-redux';
 import UserLabel from '../common/UserLabel';
+import { Header } from './Profile/Public/SkillsRow';
 import LocationSteps from './Profile/Public/LocationSteps';
 import { ThickPaddedBottom } from '../../styles/globalStyles';
 import SkillsAndInterests from './Profile/Public/SkillsRow';
 import TableRow from '../dashboard/Profile/Public/TableRow';
+import { SocialIcon } from './Profile/Public/SocialList';
 import { saveProfileStats } from '../../actions/views';
 import FCCStatTables from './Profile/Public/FCCTables';
 import Table from '../dashboard/Profile/Public/Table';
@@ -27,8 +29,10 @@ const Loader = styled.div`
   padding-bottom:  !important;
 `;
 
-const ColumnNoTopPadding = styled.div`
-  padding-top: 0 !important;
+const A = styled.a`
+  color: black !important;
+  font-weight: bold;
+  margin-left: 5px;
 `;
 
 class PublicProfile extends React.Component {
@@ -41,7 +45,10 @@ class PublicProfile extends React.Component {
   }
 
   componentDidMount() {
-    document.body.scrollTop = 0;
+    // document.body.scrollTop = 0;
+    // *** *** *** *** *** *** *** *** *** ***
+    //                    ==> UNCOMMENT WHEN DONE WORKING ON COMPONENT <==
+    // *** *** *** *** *** *** *** *** *** ***
     if (this.state.firstLoad) {
       this.longestStreak();
       this.currentStreak();
@@ -51,6 +58,20 @@ class PublicProfile extends React.Component {
       this.setState({
         firstLoad: false
       });
+    }
+  }
+
+  componentDidUpdate() {
+    // dynamically determine height of div with less content
+    // & keep side by side divs equal height to keep ui clean
+    const bioDiv = document.getElementById('mentorshipBioDiv');
+    const contactDiv = document.getElementById('contactDiv');
+    const bioHeight = bioDiv && window.getComputedStyle(bioDiv).getPropertyValue('height');
+    const contactHeight = contactDiv && window.getComputedStyle(contactDiv).getPropertyValue('height');
+    if (parseInt(bioHeight) > parseInt(contactHeight)) {
+      this.dynamicHeight = bioHeight;
+    } else {
+      this.dynamicHeight = contactHeight;
     }
   }
 
@@ -173,11 +194,17 @@ class PublicProfile extends React.Component {
       </Loader>
     );
 
+    // dynamically set height of divs per CDM logic
+    const DynamicHeightDiv = styled.div`
+      height: ${ this.dynamicHeight }
+    `;
+
     return (
       <ThickPaddedBottom id="public-profile-container">
+
+        {/* AVATAR & INTRO */}
         <div className="ui celled stackable grid container">
           <div className="row">
-
             <div className="four wide center aligned column">
               <img
                 src={user.personal.avatarUrl}
@@ -189,7 +216,6 @@ class PublicProfile extends React.Component {
                 username={user.username}
                 label={user.mentorship.isMentor ? "Mentor" : "Member"}/>
             </div>
-
             <div className="twelve wide column">
               <LocationSteps personal={user.personal} />
               <div className="ui center aligned segment">
@@ -198,19 +224,21 @@ class PublicProfile extends React.Component {
                   {user.personal.bio}
                 </div>
               </div>
-              <SocialList
-                social={user.social}
-                username={user.username}
-                profileUrl={user.personal.profileUrl} />
+              <div className="ui center aligned segment">
+                <SocialList
+                  social={user.social}
+                  username={user.username}
+                  profileUrl={user.personal.profileUrl} />
+              </div>
             </div>
-
           </div>
         </div>
 
+        {/* FCC PROFILE */}
         <div className="ui celled stackable grid container">
           <div className="row">
             <HeaderWrapper className="sixteen wide center aligned column">
-              <h2 className="ui">freeCodeCamp <i className="fa fa-free-code-camp" /></h2>
+              <h2 className="ui">freeCodeCamp Profile <i className="fa fa-free-code-camp" /></h2>
             </HeaderWrapper>
           </div>
           { this.isLoading()
@@ -218,6 +246,7 @@ class PublicProfile extends React.Component {
             : <FCCStatTables { ...this.state } username={user.username} fccCerts={user.fccCerts} /> }
         </div>
 
+        {/* CODING PROFILE */}
         <div className="ui celled stackable center aligned grid container">
           <div className="row">
             <HeaderWrapper className="sixteen wide center aligned column">
@@ -227,6 +256,7 @@ class PublicProfile extends React.Component {
           <SkillsAndInterests skillsAndInterests={user.skillsAndInterests} />
         </div>
 
+        {/* CAREER */}
         <div className="ui celled stackable center aligned grid container">
           <div className="row">
             <HeaderWrapper className="sixteen wide center aligned column">
@@ -236,32 +266,50 @@ class PublicProfile extends React.Component {
           <Career career={user.career} />
         </div>
 
+        {/* MENTORSHIP */}
         <div className="ui celled stackable center aligned grid container">
           <div className="row">
             <HeaderWrapper className="sixteen wide center aligned column">
               <h2 className="ui">Mentorship <i className="student icon" /></h2>
             </HeaderWrapper>
           </div>
-
           <div className="row">
             <Table columnWidth="sixteen">
               <TableRow
                 header="I am a freeCodeCamp Alumni Network Mentor"
                 content={ user.mentorship.isMentor
-                  ? <i title="I am a mentor" className="large green check mark icon"/>
-                : <i title="I am a member / mentee" className="large red remove icon"/> } />
-              </Table>
-
-            { user.mentorship.isMentor &&
-              <ColumnNoTopPadding className="sixteen wide center aligned column">
-              <div className="ui segment">
-                <div className="ui horizontal divider">Contact:</div>
-                For mentorship requests I can be reached by email at:
-                <a href={`mailto:${user.personal.email}?subject=fCC%20Alumni%20Network%20/%20Mentorship%20Request`}>{` ${user.personal.email}`}</a>
-                <div className="ui horizontal divider">Mentorship Skills:</div>
+                  ? <i className="large green check mark icon"/>
+                  : <i className="large red remove icon"/> } />
+              <TableRow
+                header="I am open to being Mentored by other Members"
+                content={ user.mentorship.isMentee
+                  ? <i className="large green check mark icon"/>
+                  : <i className="large red remove icon"/> } />
+            </Table>
+          </div>
+          <div className="row">
+          { user.mentorship.mentorshipSkills &&
+            <div className="eight wide center aligned column">
+              <Header className="ui top attached header">
+                Mentorship Bio
+              </Header>
+              <DynamicHeightDiv id="mentorshipBioDiv" className="ui attached segment">
                 { user.mentorship.mentorshipSkills }
-              </div>
-            </ColumnNoTopPadding> }
+              </DynamicHeightDiv>
+            </div> }
+            <div className={`${user.mentorship.mentorshipSkills ? 'eight' : 'sixteen'} wide center aligned column`}>
+              <Header className="ui top attached header">
+                Contact for Mentorship & Other Requests
+              </Header>
+              <DynamicHeightDiv id="contactDiv" className="ui attached segment">
+                <SocialList
+                  contactsOnly={true}
+                  social={user.social}
+                  username={user.username}
+                  email={user.personal.email}
+                  profileUrl={user.personal.profileUrl} />
+              </DynamicHeightDiv>
+            </div>
           </div>
         </div>
 

--- a/client/src/styles/components/_SliderToggle.scss
+++ b/client/src/styles/components/_SliderToggle.scss
@@ -27,7 +27,7 @@
     }
     &:before {
       content: 'ON';
-      color: #007E00;
+      color: lighten(#006400, 60%);
       position: absolute;
       left: 10px;
       z-index: 0;
@@ -48,4 +48,8 @@
       box-shadow: 0px 2px 5px 0px rgba(0,0,0,0.3);
     }
   }
+}
+
+.slider-toggle-container:nth-of-type(3) {
+  margin: 5px 0 0 0;
 }


### PR DESCRIPTION
- need to selectively render each bit of info based on what the user does and does not fill out on preferences page
- added new slider in preferences page to select "willing to be mentored" (decided that mentoring and being mentored should not be mutually exclusive - you can select both), and lets you add both what you can mentor in and what you would like to be mentored in in the same "mentorship bio" (mentorship bio input shows up if either slider is toggled "on"
- render height of side by side divs dynamically in profile page to keep ui clean (both divs render to height of taller div), can use this in other places, but for now only in one.
- modified `socialList` component to render selectively
- modified mentorship section to render selectively