### PR TITLE
preferences page validations, enable true save by section

### DIFF
--- a/client/src/actions/user.js
+++ b/client/src/actions/user.js
@@ -25,6 +25,10 @@ export const updateUser = (user) => {
   return axios.post('/api/update-user', { user });
 }
 
+export const updateUserPartial = (id, section, sectionData) => {
+  return axios.post('/api/update-user-partial', { id, section, sectionData });
+}
+
 export const logoutUser = () => {
   return {
     type: LOGOUT_USER

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -41,10 +41,10 @@ class NavBar extends React.Component {
     const guestNav = (
       <div className={`ui huge fixed stackable inverted borderless ${darkGreen} menu`}>
         <NavLink className="item" activeClassName="item active" exact to="/"><Logo src="/images/fcc_high_five_logo.svg" />freeCodeCamp Alumni Network</NavLink>
-        <div className="right menu" id={isDesktop ? '' : 'navMenu'}>
+        <div className="right menu" id={!isDesktop && 'navMenu'}>
           <MenuRight>
-            <NavLink className="item link" activeClassName="item active" exact to="/about">About</NavLink>
-            <NavLink className="item link" activeClassName="item active" exact to="/login">Login</NavLink>
+            <NavLink className="item" activeClassName="item active" exact to="/about">About</NavLink>
+            <NavLink className="item" activeClassName="item active" exact to="/login">Login</NavLink>
           </MenuRight>
         </div>
       </div>

--- a/client/src/components/common/RepoList.js
+++ b/client/src/components/common/RepoList.js
@@ -68,7 +68,7 @@ class RepoList extends React.Component {
     validateOtherRepos(item, hostUrl).then((res) => {
       if (res) {
         items_list.push({item, label});
-        this.setState({ items_list, item: '', isLoading: false }, () => this.props.saveChanges(false));
+        this.setState({ items_list, item: '', isLoading: false }, () => this.props.saveChanges());
       } else {
         this.setState({
           error: {
@@ -203,7 +203,7 @@ class RepoList extends React.Component {
             if (contributor.author.login === username) {
               isContributor = true;
               items_list.push({item, label});
-              this.setState({ items_list, item: '', isLoading: false }, () => this.props.saveChanges(false));
+              this.setState({ items_list, item: '', isLoading: false }, () => this.props.saveChanges());
             }
           }
           // if user is not listed, repo may have > 100 contributors
@@ -217,7 +217,7 @@ class RepoList extends React.Component {
               if (commits.length > 0) {
                 isContributor = true;
                 items_list.push({item, label});
-                this.setState({ items_list, item: '', isLoading: false }, () => this.props.saveChanges(false));
+                this.setState({ items_list, item: '', isLoading: false }, () => this.props.saveChanges());
               }
             })
             .catch((err) => {
@@ -261,7 +261,7 @@ class RepoList extends React.Component {
 
   removeItem = (item) => {
     const items_list = this.spliceList(item);
-    this.setState({ items_list }, () => this.props.saveChanges(false));
+    this.setState({ items_list }, () => this.props.saveChanges());
 
   }
 

--- a/client/src/components/dashboard/Chat/ChatModal.js
+++ b/client/src/components/dashboard/Chat/ChatModal.js
@@ -3,17 +3,11 @@ import React from 'react';
 import { Modal, Button } from 'semantic-ui-react';
 
 export default ({ size, close, open }) => {
-  const green = '#007E00';
-  const fireStyle = {
-    width: "45px",
-    height: "45px",
-    marginBottom: "-5px"
-  }
-  return(
+  return (
     <div>
       <Modal size={size} open={open} onClose={close}>
 
-        <Modal.Header style={{ background: green, color: 'white' }}>
+        <Modal.Header style={{ background: '#007E00', color: 'white' }}>
           <h1>
             <span>Mess Hall Chat &nbsp;</span>
           </h1>
@@ -52,14 +46,14 @@ export default ({ size, close, open }) => {
 
         </Modal.Content>
 
-        <Modal.Actions style={{ background: 'rgb(248,248,248)' }}>
+        <Modal.Actions>
           <Button
             positive
             content='Ok'
             onClick={close}
             icon='checkmark'
             labelPosition='right'
-            style={{ background: green }} />
+            color="green" />
         </Modal.Actions>
 
       </Modal>

--- a/client/src/components/dashboard/Profile/Career.js
+++ b/client/src/components/dashboard/Profile/Career.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from 'styled-components';
 import Ribbon from './common/RibbonHeader';
 import { Dropdown } from 'semantic-ui-react';
 import FormField from '../../common/FormField';
@@ -6,6 +7,15 @@ import MessageBox from '../../common/MessageBox';
 import RadioButton from '../../common/RadioButton';
 
 import { surveyOptions } from '../../../assets/data/dropdownOptions';
+
+const Error = styled.div`
+  margin-bottom: 10px !important;
+  cursor: pointer;Error
+`;
+
+const Button = styled.div`
+  margin-top: -10px !important;
+`;
 
 const Career = ({
   errors,
@@ -15,6 +25,7 @@ const Career = ({
   company,
   jobSearch,
   showPopUp,
+  clearForm,
   showCareer,
   subSaveClick,
   handleInputChange,
@@ -36,6 +47,10 @@ const Career = ({
           type="info"
           dismissable={true}
           message="Please let us know about your career so other members can track your accomplishments in your field." />
+        { errors.career &&
+          <Error className="ui red basic label">
+            {errors.career}
+          </Error> }
         <div className="inline fields">
           <label>Are you employed as a software developer?</label>
           <RadioButton
@@ -66,6 +81,7 @@ const Career = ({
             placeholder="Enter Company"
             onChange={handleInputChange}
             label="Where are you currently employed?" />
+          <Button onClick={clearForm} className="ui tiny green basic button">Clear Form</Button>
         </div>
         <div className={`surveyPaneWorking ${working === 'no' ? 'show' : 'hide'}`}>
           <div className="inline fields">
@@ -94,6 +110,7 @@ const Career = ({
               value={tenure}
               onChange={handleTenureChange} />
           </div>
+          <Button onClick={clearForm} className="ui tiny green basic button">Clear Form</Button>
         </div>
       </div>
     </div>

--- a/client/src/components/dashboard/Profile/Certifications.js
+++ b/client/src/components/dashboard/Profile/Certifications.js
@@ -7,7 +7,7 @@ const Item = styled.h5`
   margin-top: 2px !important;
 `;
 
-const Certifications = ({ toggle, fccCerts, showPopUp, showFCC }) => {
+const Certifications = ({ toggle, fccCerts, showFCC }) => {
   var certs = [];
   for (var cert in fccCerts) {
     if (fccCerts[cert]) {
@@ -26,9 +26,7 @@ const Certifications = ({ toggle, fccCerts, showPopUp, showFCC }) => {
   return (
     <div>
       <Ribbon
-        id="fccPopUp"
         showSave={false}
-        showPopUp={showPopUp}
         wrapperClass="fccWrapper"
         content="freeCodeCamp Certifications"
         onClick={() => { toggle('showFCC')}} />

--- a/client/src/components/dashboard/Profile/Collaboration.js
+++ b/client/src/components/dashboard/Profile/Collaboration.js
@@ -16,7 +16,7 @@ const Collaboration = ({
   return (
     <div>
       <Ribbon
-        id="collaboPopUp"
+        id="projectsPopUp"
         content="Collaboration"
         showPopUp={showPopUp}
         subSaveClick={subSaveClick}

--- a/client/src/components/dashboard/Profile/Public/CareerRow.js
+++ b/client/src/components/dashboard/Profile/Public/CareerRow.js
@@ -3,6 +3,7 @@ import Table from './Table';
 import TableRow from './TableRow';
 
 const CareerRow = ({ career }) => {
+  console.log(career)
   const TableToRender = career.working === "no"
     ? <Table columnWidth="sixteen">
         <TableRow

--- a/client/src/components/dashboard/Profile/SkillsAndInterests.js
+++ b/client/src/components/dashboard/Profile/SkillsAndInterests.js
@@ -9,13 +9,13 @@ import { skills, interests } from '../../../assets/data/dropdownOptions';
 const SkillsAndInterests = ({ showSkills, subSaveClick, showPopUp, toggle, handleSkillsChange, handleInterestsChange, coreSkills, codingInterests }) => {
   return (
     <div>
-      <Ribbon 
-        showPopUp={showPopUp} 
-        id="skillsPopUp"
+      <Ribbon
+        showPopUp={showPopUp}
+        id="skillsAndInterestsPopUp"
         showSave={showSkills}
         subSaveClick={subSaveClick}
-        content="Skills & Interests" 
-        wrapperClass="skillsWrapper" 
+        content="Skills & Interests"
+        wrapperClass="skillsWrapper"
         onClick={()=>{toggle('showSkills')}} />
       <div className={`skillsPane ${showSkills ? 'show' : 'hide'}`}>
         <DividingHeader size="h4" content="Core Skills" icon="checkmark box icon" />

--- a/client/src/components/dashboard/Profile/common/RibbonHeader.js
+++ b/client/src/components/dashboard/Profile/common/RibbonHeader.js
@@ -13,7 +13,7 @@ const RibbonHeader = ({ content, onClick, wrapperClass, showPopUp, subSaveClick,
           </div>
         }
       </div>
-      <div className={`ui left pointing basic green label savedPopUp ${showPopUp ? 'show' : 'hide'}`}>Saved</div>
+      <div className={`ui left pointing basic green label savedPopUp ${showPopUp ? 'show' : 'hide'}`}>Section Saved</div>
     </div>
   );
 }

--- a/client/src/components/dashboard/Profile/common/SaveModal.js
+++ b/client/src/components/dashboard/Profile/common/SaveModal.js
@@ -1,16 +1,23 @@
 import React from 'react';
 import { Modal, Button } from 'semantic-ui-react';
 
-const SaveModal = ({ size, close, open }) => {
-  const green = '#00b5ad';
-  return(
+const SaveModal = ({ size, close, open, isValid }) => {
+
+  const context = {
+    header: isValid ? 'Success' : 'Error',
+    headerColor: isValid ? '#007E00' : '#FF4025',
+    text: isValid ? 'Your profile has been successfully updated!' : 'Please correct the errors and try again.',
+    buttonColor: isValid ? 'green' : 'red'
+  }
+
+  return (
     <div>
       <Modal size={size} open={open} onClose={close}>
-        <Modal.Header>
-          Success
+        <Modal.Header style={{ background: context.headerColor, color: 'white'}}>
+          { context.header }
         </Modal.Header>
         <Modal.Content>
-          <p>Your profile has been successfully updated!</p>
+          <h4 className="ui header">{context.text}</h4>
         </Modal.Content>
         <Modal.Actions>
           <Button
@@ -19,7 +26,7 @@ const SaveModal = ({ size, close, open }) => {
             onClick={close}
             icon='checkmark'
             labelPosition='right'
-            style={{ background: green }} />
+            color={context.buttonColor} />
         </Modal.Actions>
       </Modal>
     </div>

--- a/client/src/components/signup/LoginPage.js
+++ b/client/src/components/signup/LoginPage.js
@@ -2,35 +2,35 @@ import React from 'react';
 import { APP_HOST } from '../../actions/chat';
 import { connectScreenSize } from 'react-screen-size';
 import { mapScreenSizeToProps } from '../Navbar';
+import styled from 'styled-components';
 
 const LoginPage = ({ screen: { isTablet, isMobile, isDesktop }}) => {
-  return (
-    <div className="ui center aligned grid" style={{ marginTop: `${isDesktop ? '175px' : '125px' }`}}>
-      <div className={`${isMobile ? 'twelve' : isTablet ? 'ten' : 'six'} wide column`}>
 
+  const LoginContainer = styled.div`
+    margin-top: ${isDesktop ? '200px' : '175px' } !important;
+  `;
+
+  return (
+    <LoginContainer className={`ui center aligned grid ${isDesktop && 'container'}`}>
+      <div className={`${isMobile ? 'twelve' : isTablet ? 'ten' : 'six'} wide column`}>
         <div className="ui segment">
           <h2 className="ui green image header">
             { !isMobile && <i className="huge github icon"/> }
             <div className="content">Login with GitHub</div>
           </h2>
-
           <div className="ui segment">
             <a className="ui green button" href={`${APP_HOST}/auth/github`}>Login</a>
           </div>
-
           <div className="ui info message">
             <div className="header">Joining the freeCodeCamp Alumni Network requires both freeCodeCamp and GitHub credentials.</div>
           </div>
         </div>
-
-        { isDesktop &&
-          <div className="center aligned segment">
-            <i id="arrow-bounce" className="massive green arrow up icon"/>
-          </div>
-        }
-
+      { isDesktop &&
+        <div className="center aligned segment">
+          <i id="arrow-bounce" className="massive green arrow up icon"/>
+        </div> }
       </div>
-    </div>
+    </LoginContainer>
   );
 }
 

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -37,7 +37,7 @@
 }
 
 #navMenu {
-  .link {
+  .item {
     width: 50vw !important;
   }
 }

--- a/client/src/styles/components/_Profile.scss
+++ b/client/src/styles/components/_Profile.scss
@@ -2,8 +2,9 @@
 #saveButton {
   float: right;
   cursor: pointer;
+  transition: color 150ms ease-in-out;
   &:hover {
-    color: rgb(10, 97, 89) !important;
+    color:  lighten(#007E00, 60%) !important;
   }
 }
 

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -98,4 +98,20 @@ router.post('/api/update-user', (req, res) => {
   });
 });
 
+router.post('/api/update-user-partial', (req, res) => {
+  const { id, section, sectionData } = req.body;
+  
+  User.findById(id, (err, updatedUser) => {
+    if (!err) {
+      updatedUser[section] = sectionData;
+
+      updatedUser.save();
+
+      res.json({ updatedUser })
+    } else {
+      res.status(401).json({ error: 'User could not be saved' });
+    }
+  });
+});
+
 export default router;


### PR DESCRIPTION
- slight changes to login page styles (will need to revisit fixed margin due to flash messages)
- enabled true save by section on preferences page, this way saving a section would not trigger errors in another section that user might not see
- added validations for mentorship - must add bio of either option is toggled "on"
- added validations for career - must answer all 3 questions if answer one
- gave user option to clear career form for better UX, otherwise they would have to refresh to clear form if they did not want to answer questions
- changed modal styles to be consistent with out fcc theme