### PR TITLE
Implemeneted delete user

### DIFF
--- a/client/src/actions/user.js
+++ b/client/src/actions/user.js
@@ -34,3 +34,5 @@ export const logoutUser = () => {
     type: LOGOUT_USER
   }
 }
+
+export const deleteUser = () => axios.post('/api/delete-user');

--- a/client/src/components/AppContainer.js
+++ b/client/src/components/AppContainer.js
@@ -15,6 +15,7 @@ import Mentorship from './dashboard/Mentorship';
 import Chat from './dashboard/Chat/ChatController';
 import Profile_Config from './dashboard/Profile_Config';
 import Profile_Public from './dashboard/Profile_Public';
+import Account from './dashboard/Account';
 
 class AppContainer extends React.Component {
 
@@ -76,6 +77,7 @@ class AppContainer extends React.Component {
             <Route exact path={`${url}/mentorship`} component={Mentorship}/>
             <Route exact path={`${url}/chat`} component={Chat}/>
             <Route exact path={`${url}/chat/:username`} component={Chat}/>
+            <Route exact path={`${url}/account`} component={Account}/>
             <Route component={CatchAll} />
           </Switch> }
       </div>

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -53,10 +53,15 @@ class NavBar extends React.Component {
     const userNav = (
       <div>
         {!this.state.nav ?
+
           <div className={`ui huge fixed stackable inverted borderless ${darkGreen} menu`}>
             <div className="item" onClick={this.toggleNav}><Logo src="/images/fcc_high_five_logo.svg" />freeCodeCamp Alumni Network</div>
-          </div> :
+          </div>
+
+          :
+
           <div className={`ui huge fixed stackable inverted borderless ${darkGreen} menu`}>
+
             {isDesktop ?
               <NavLink className="item" activeClassName="active item" exact to="/dashboard">
                 <Logo src="/images/fcc_high_five_logo.svg" />freeCodeCamp Alumni Network</NavLink> :
@@ -64,14 +69,22 @@ class NavBar extends React.Component {
                   <div className="item" onClick={this.toggleNav}><Logo src="/images/fcc_high_five_logo.svg" />freeCodeCamp Alumni Network</div>
                   <NavLink className="item" activeClassName="active item" exact to="/dashboard">Dashboard</NavLink>
                 </div>}
+
             <NavLink className="item" activeClassName="active item" exact to="/dashboard/preferences">Profile</NavLink>
             <NavLink className="item" activeClassName="active item" exact to="/dashboard/community">Community</NavLink>
             <NavLink className="item" activeClassName="active item" exact to="/dashboard/mentorship">Mentorship</NavLink>
             <NavLink className="item" activeClassName="active item" exact to="/dashboard/chat">Mess Hall</NavLink>
-            <div className="right menu">
+
+            <div className={`${isDesktop ? 'right menu' : ''}`}>
+              <NavLink className ="item" activeClassName="active item" exact to="/dashboard/account">
+                {isDesktop ? <i className="setting icon"></i> : 'Account'}
+              </NavLink>
               <a className="item" href={`${APP_HOST}/logout`}>Logout</a>
             </div>
-          </div> }
+
+          </div>
+
+        }
       </div>
     );
     return (

--- a/client/src/components/dashboard/Account.js
+++ b/client/src/components/dashboard/Account.js
@@ -1,0 +1,124 @@
+/* eslint-disable */
+import React from 'react';
+import { connect } from 'react-redux';
+import { deleteUser, logoutUser } from '../../actions/user';
+import { Modal, Button } from 'semantic-ui-react';
+import { addFlashMessage, clearFlashMessage } from '../../actions/flashMessages';
+
+const ConfirmModal = ({ open, input, handleInput, deleteUser, close }) => {
+  return (
+    <Modal size="small" open={open}>
+
+      <Modal.Header style={{ background: 'rgb(225,225,225)' }}>
+        <h1>
+          <span>Type your username to confirm:</span>
+        </h1>
+      </Modal.Header>
+
+      <Modal.Content>
+        <form onSubmit={deleteUser}>
+          <input
+            autoFocus
+            autoComplete='off'
+            id="deleteInput"
+            type="text"
+            value={input}
+            onChange={handleInput} />
+        </form>
+      </Modal.Content>
+
+      <Modal.Actions style={{ textAlign: 'center' }}>
+        <Button
+          content='Delete Account'
+          color="red"
+          onClick={deleteUser}
+          icon='remove'
+          labelPosition='right' />
+        <Button
+          positive
+          content='Nevermind'
+          color="green"
+          onClick={close}
+          icon='undo'
+          labelPosition='right' />
+      </Modal.Actions>
+
+    </Modal>
+  );
+};
+
+
+class Account extends React.Component {
+  state = {
+    modal: false,
+    input: ''
+  }
+  deleteUser = (e) => {
+    if (e) e.preventDefault();
+    const { input } = this.state;
+    this.setState({ input: '' });
+    if (input === this.props.user) {
+      deleteUser().then(res => {
+        this.props.logoutUser();
+        this.props.clearFlashMessage();
+        this.props.addFlashMessage({
+          type: 'error',
+          text: {
+            header: 'Your account has been deleted.',
+            message: 'Goodbye!'
+          }
+        });
+        this.props.history.push('/login');
+      }).catch(err => {
+        this.props.addFlashMessage({
+          type: 'error',
+          text: {
+            header: 'Something went wrong...',
+            message: 'Hmmm...'
+          }
+        });
+      })
+    } else {
+      this.toggleModal();
+      this.props.addFlashMessage({
+        type: 'error',
+        text: {
+          header: 'Delete User Error.',
+          message: 'You must enter your username correctly if you want to delete your account.'
+        }
+      });
+    }
+  }
+  handleInput = (e) => this.setState({ input: e.target.value });
+  toggleModal = () => this.setState({ modal: !this.state.modal });
+  render() {
+    return (
+      <div className="ui main text container" id="accountSettings">
+        <div className='ui segment' style={{ padding: '25px' }}>
+          <h1 className="ui header">Account Settings for: {this.props.user}</h1>
+          <button className="ui red button" onClick={this.toggleModal}>Delete My Account</button>
+          <br /><br />
+          <p>This cannot be undone.</p>
+          <ConfirmModal
+            open={this.state.modal}
+            input={this.state.input}
+            handleInput={this.handleInput}
+            deleteUser={this.deleteUser}
+            close={this.toggleModal} />
+        </div>
+      </div>
+    );
+  }
+};
+
+const mapStateToProps = (state) => ({
+  user: state.user.username
+});
+
+const dispatchProps = {
+  addFlashMessage,
+  clearFlashMessage,
+  logoutUser
+};
+
+export default connect(mapStateToProps, dispatchProps)(Account);

--- a/client/src/components/dashboard/Chat/ChatController.js
+++ b/client/src/components/dashboard/Chat/ChatController.js
@@ -281,7 +281,12 @@ const mapStateToProps = ({ user, chat, privateChat, community, onlineStatus }, p
     try {
       conversantAvatar = community.find(u => u.username === username).personal.avatarUrl;
     } catch (e) {
-      console.warn('Chat Controller waiting on props...');
+      if (community.size) {
+        console.log('Community exists but there is no such user, redirect:')
+        props.history.push('/dashboard/chat');
+      } else {
+        console.warn('Chat Controller waiting on props...');
+      }
     }
     try {
       totalNotifications = privateChat.reduce((t,c) => t + c.get('notifications'), 0);

--- a/client/src/components/signup/PassportPage.js
+++ b/client/src/components/signup/PassportPage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import { getUserData, verifyUser, saveUser } from '../../actions/user';
+import { getUserData, verifyUser, saveUser, deleteUser } from '../../actions/user';
 import { addFlashMessage } from '../../actions/flashMessages';
 import { connect } from 'react-redux';
 import { socket } from '../../actions/chat';
@@ -40,10 +40,6 @@ class PassportPage extends React.Component {
     });
   }
 
-  handleChange = (e) => {
-    this.setState({ username: e.target.value });
-  }
-
   handleSubmit = (e) => {
     e.preventDefault();
     const { username, mongoId } = this.state;
@@ -71,8 +67,12 @@ class PassportPage extends React.Component {
           message: 'Either you have not earned any freeCodeCamp certifications, or you do not have a freeCodeCamp account. Please visit us again when you have resolved these issues.'
         }
       });
-      this.props.history.push('/');
-    })
+      deleteUser().then(res => {
+        console.log('user deleted');
+      }).catch(err => {
+        console.log('Some error occurred trying to delete the unverified user...');
+      });
+    });
   }
 
   render() {
@@ -84,11 +84,17 @@ class PassportPage extends React.Component {
 
     const pageContent = (
       <div className='ui container'>
-        <h1>{`Welcome ${this.state.displayName}!`}</h1>
-        { this.state.avatarUrl.length > 0 && <div className="ui small image"><img src={this.state.avatarUrl} alt="github avatar"/></div> }
-        <br /><br />
-        <p>This extension of the freeCodeCamp Community is a network of like-minded individuals, who are serious about coding and about taking their skills to the next level.</p>
-        <p>While our goal is to be as inclusive as possible, to ensure that this network maintains its integrity as a serious place for serious campers, we do have some requirements that limit who can and cannot join.</p>
+
+        <div className='ui segment' style={{ fontSize: '18px', minHeight: '235px' }}>
+          <h1>{`Welcome ${this.state.displayName}!`}</h1>
+          { this.state.avatarUrl.length > 0 &&
+            <div className="ui small floated left image">
+              <img src={this.state.avatarUrl} alt="github avatar"/>
+            </div> }
+          <p>This extension of the freeCodeCamp Community is a network of like-minded individuals, who are serious about coding and about taking their skills to the next level.</p>
+          <p>While our goal is to be as inclusive as possible, to ensure that this network maintains its integrity as a serious place for serious campers, we do have some requirements that limit who can and cannot join.</p>
+        </div>
+
         <div className="ui info message">
           <div className="header">To join the freeCodeCamp Alumni Network, you must have earned at least one of the following:</div>
           <ul className="list">
@@ -98,18 +104,11 @@ class PassportPage extends React.Component {
             <li>freeCodeCamp Full Stack Certification</li>
           </ul>
         </div>
-        <h4>If your freeCodeCamp username is not the same as what is listed below, please change it so that we can pull the correct data from freeCodeCamp. Then, to continue, please click the button below, which will verify your eligibility to join based on the above gudilines. Thanks!</h4>
-        <form style={{ paddingBottom: 50 }} onSubmit={this.handleSubmit} className="ui form">
-          <div className="inline field">
-            <label>Username:</label>
-            <div className="ui input small">
-              <input
-                value={this.state.username}
-                onChange={this.handleChange} />
-            </div>
-          </div>
-          <button type="submit" className="ui button">Verify Free Code Camp User Data</button>
-        </form>
+
+        <button onClick={this.handleSubmit} className="ui positive button">Verify freeCodeCamp Certifications for {this.state.username}</button>
+        <p style={{ marginTop: '15px', marginBottom: '15px' }}>
+          <b>Note:</b> If your freeCodeCamp username is not <b>{this.state.username}</b>, please send an email to Pete's Computer.
+        </p>
       </div>
     );
 

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -35,3 +35,14 @@
 .free.code.camp.icon {
   margin-right: .3rem !important;
 }
+
+#accountSettings {
+  text-align: center;
+  margin-top: 150px;
+}
+#deleteInput {
+  width: 100%;
+  border: 1px solid rgba(5,5,5,0.25);
+  padding: 4px 6px;
+  font-size: 22px;
+}


### PR DESCRIPTION
Implements delete user functionality. I created a new route after all for this and put the `navLink` next to Logout. I mostly did this just to put it somewhere separate and maybe in the future there will be additional options in `/acccount` we want to have here.

I think this is tentatively working and guarding against errors that could occur in chat. Deleting a user removes them from chat and private chat like we discussed. If another user A is logged in when user B deletes their account and user A tries to chat with user B, user A will see flash errors but that's all. If they refresh they should be good to go. And the errors won't break the app, user A just won't be able to actually send messages to user B, like messages, etc.

This also modifies the verification stage of the authentication process and prevents users from changing their username. If the verification fails they are deleted from the database.

I looked at LinkedIn API thing, couldn't do anything so I vote just table this to production.

Also, the flash messages margins cause them to interfere with the page content in other views too, not just `about` but also on the `delete user` route for instance. I don't know if we should adjust the content on these pages or adjust the flash message styling — but since @no-stack-dub-sack modified them recently I'm going to leave this for feedback from him.