### PR TITLE
Uses Redux to manage user stats

### DIFF
--- a/client/src/actions/community.js
+++ b/client/src/actions/community.js
@@ -1,18 +1,10 @@
 import axios from 'axios';
 
 export const POPULATE = 'POPULATE';
-export const POPULATE_DEFAULT_STATS = 'POPULATE_DEFAULT_STATS';
 
 const receiveCommunity = (users) => {
   return {
     type: POPULATE,
-    users
-  }
-}
-
-const createCommunityStats = (users) => {
-  return {
-    type: POPULATE_DEFAULT_STATS,
     users
   }
 }
@@ -22,7 +14,6 @@ export const populateCommunity = () => {
     return axios.get('/api/community').then(res => {
       const { users } = res.data;
       dispatch(receiveCommunity(users));
-      dispatch(createCommunityStats(users));
     }).catch(err => console.log(err));
   }
 };

--- a/client/src/actions/scrape-fcc.js
+++ b/client/src/actions/scrape-fcc.js
@@ -1,0 +1,102 @@
+import axios from 'axios';
+import htmlToJson from 'html-to-json';
+
+export const POPULATE_USER_STATS = 'POPULATE_USER_STATS';
+
+/* helper function to scrape user FCC stats while we design a better solution: */
+export const scrapeFccStats = (user) => (dispatch) => {
+  axios.get(`https://www.freecodecamp.com/${user}`).then(html => {
+
+    // FIRST CHALLENGE COMPLETED
+    const firstChallenge = htmlToJson.parse(html.data, {
+      'text': (doc) => {
+        return doc.find('div').text();
+      }
+    }).then(result => {
+      if (!/Challenges\s*Completed/.test(result.text)) {
+        return "Sorry, no data";
+      } else {
+        result = result.text.match(/Challenges\s*Completed.*?\d{4}/)[0];
+        return result.slice(-12);
+      }
+    }).catch(err => {
+      return null;
+    });
+
+    // TOTAL CHALLENGES COMPLETED
+    const totalChallenges = htmlToJson.parse(html.data, function() {
+      return this.map('tr .col-xs-5', (item) => {
+        return item.text();
+      });
+    }).then(items => {
+      return items.length;
+    }).catch(err => {
+      return null;
+    });
+
+    // LONGEST STREAK
+    const longestStreak = htmlToJson.parse(html.data, {
+      'text': function(doc) {
+        return doc.find('h4').text();
+      }
+    }).then(result => {
+      result = result.text.match(/Longest\sStreak:\s\d+/)[0];
+      var dayOrDays = result.slice(16) === "1"
+        ? " Day"
+        : " Days";
+      return result.slice(16) + dayOrDays;
+    }).catch(err => {
+      return null;
+    });
+
+    // CURRENT STREAK
+    const currentStreak = htmlToJson.parse(html.data, {
+      'text': function(doc) {
+        return doc.find('h4').text();
+      }
+    }).then(result => {
+      result = result.text.match(/Current\sStreak:\s\d+/)[0];
+      var dayOrDays = result.slice(16) === "1"
+        ? " Day"
+        : " Days";
+      return result.slice(16) + dayOrDays;
+    }).catch(err => {
+      return null;
+    });
+
+    // BROWNIE POINTS
+    const browniePoints = htmlToJson.parse(html.data, {
+      'text': function(doc) {
+        return doc.find('h1').text();
+      }
+    }).then(result => {
+      result = result.text.match(/\[\s\d*\s\]/)[0];
+      return result.slice(2, -2);
+    }).catch(err => {
+      return null;
+    });
+
+    Promise.all([
+      firstChallenge,
+      totalChallenges,
+      longestStreak,
+      currentStreak,
+      browniePoints
+    ]).then((values) => {
+      dispatch({
+        type: POPULATE_USER_STATS,
+        payload: {
+          user,
+          stats: {
+            firstChallenge: values[0],
+            totalChallenges: values[1],
+            longestStreak: values[2],
+            currentStreak: values[3],
+            browniePoints: values[4],
+          }
+        }
+      })
+    }).catch(err => console.warn('Something went wrong fetching user FCC stats...'));
+
+  });
+}

--- a/client/src/actions/views.js
+++ b/client/src/actions/views.js
@@ -17,10 +17,3 @@ export const savePreferencesViewState = (preferencesView) => {
     preferencesView
   }
 }
-
-export const saveProfileStats = (stats) => {
-  return {
-    type: SAVE_PROFILE_STATS,
-    stats
-  }
-}

--- a/client/src/reducers/publicProfileStats.js
+++ b/client/src/reducers/publicProfileStats.js
@@ -1,31 +1,13 @@
-import { SAVE_PROFILE_STATS } from '../actions/types';
-import { POPULATE_DEFAULT_STATS } from '../actions/community';
 
-const defaultStats = {
-  firstChallenge: '',
-  totalChallneges: '',
-  longestStreak: '',
-  currentStreak: '',
-  browniePoints: '',
-  isLoadingA: true,
-  isLoadingB: true,
-  isLoadingC: true,
-  isLoadingD: true,
-  isLoadingE: true,
-  firstLoad: true,
-}
+import { POPULATE_USER_STATS } from '../actions/scrape-fcc.js';
+import { Map } from 'immutable';
 
-export default (state = defaultStats, action) => {
-  switch (action.type) {
+export default (state = Map(), action) => {
+  const { type, payload } = action;
+  switch (type) {
 
-    case POPULATE_DEFAULT_STATS:
-      var defaultState = {};
-      action.users.forEach(user =>
-        defaultState[user.username] = defaultStats);
-      return defaultState;
-
-    case SAVE_PROFILE_STATS:
-      return Object.assign(state, action.stats);
+    case POPULATE_USER_STATS:
+      return state.set(payload.user, payload.stats);
 
     default: return state;
   }


### PR DESCRIPTION
@no-stack-dub-sack this should do it. Sorry I couldn't resist!!! :sob:

User stats are now fetched once per user per app session and persisted in Redux.

The only thing else might be to implement some kind of error handling in case one of the parsing events fails. I'm setting the value to `null` in this case not the `ERROR` message from before. I assume it would render nothing in that box if it's field is set to `null`, which is a decent response if we can't get the data for some reason.

Various challenges appeared here: asynchronicity as always... `htmlToJson` is asynchronous. Also, possibly, `connect`'s caching behavior. I think the real issue was the former.

And I couldn't stop from using Immutable for the Redux state here...

Finally, I removed the other code you had written for this unfinished feature since I think this PR finishes it. Also, even though this entire thing is somewhat contrived, I think it is pretty isolated now to two files (actions and store reducer) so should be OK to replace if we later integrate this logic into the user schema.

Anyway — I'm going to merge this and deploy so it's on the app by tomorrow. 🚀 