### PR TITLE
Implements user whitelist

### DIFF
--- a/client/src/components/dashboard/Chat/ChatModal.js
+++ b/client/src/components/dashboard/Chat/ChatModal.js
@@ -30,7 +30,7 @@ export default ({ size, close, open }) => {
           <br/><br/>
 
           <i className="student icon mentorIcon"></i> These people are mentors<br/>
-          <i className="star icon green onlineIcon"></i> These people are currently online
+          <i className="star icon onlineIcon" style={{ color: 'rgb(255, 109, 88)' }}></i> These people are currently online
 
           <br/><br/>
 

--- a/client/src/components/dashboard/Mentorship.js
+++ b/client/src/components/dashboard/Mentorship.js
@@ -93,7 +93,10 @@ class Mentorship extends React.Component {
       type: 'info',
         text: {
           header: 'Welcome to Mentorship Search!',
-          message: 'Utilize our mentorship match engine to identify the right mentor for you. Narrow down your results by searching a specific category or by enabling filters.'
+          message: `Utilize our mentorship match engine to identify the right mentor for you.
+                    Narrow down your results by searching a specific category or by enabling
+                    filters. If you think you've found a good match, feel free to reach out
+                    through private chat!`
         }
     });
   }

--- a/client/src/components/dashboard/Profile/Mentorship.js
+++ b/client/src/components/dashboard/Profile/Mentorship.js
@@ -45,7 +45,12 @@ class Mentorship extends React.Component {
           <MessageBox
             type="info"
             header="Would you like to be a mentor?"
-            message="The main goal of this community is to bring together programmers of varying degrees of skill, and connect them with one another to form meaningful mentor/mentee relationships. If you are interested in becoming a mentor, please toggle the switch and provide a short description in the textbox below of the programming skills that you feel comfortable mentoring someome in. Your entite profile is searchable, but prospective mentees can search our database for mentors that share the same skills and intertests (which everyone can define in the next section), who live in their area, or who have cited skills they need tutelage in within their menotrship bio. For now, the burden is on the mentee (we are looking into a smarter, automated matching system) &mdash; when a mentee has found a good match, they can reach out to you through our private chat feature, so be sure to check back periodically for notifications! This setting can be turned off at any time here in your user preferences dashboard." />
+            message="The main goal of this community is to bring together programmers of varying degrees of skill,
+            and connect them with one another to form meaningful mentor/mentee relationships. If you are interested
+            in becoming a mentor, please toggle the switch and provide a short description of the core competencies
+            you could mentor others in. Your profile will be searchable based on all the criteria provided here for
+            prospective mentees who can contact you via private chat, or your email if you provide it. We encourage
+            all members to be proactive and creative in building these relationships!" />
           <SliderToggle
             defaultOn={isMentor ? true : false}
             saveStateToParent={toggleMentorship}

--- a/client/src/components/signup/UserVerification.js
+++ b/client/src/components/signup/UserVerification.js
@@ -15,7 +15,7 @@ class UserVerification extends React.Component {
     avatarUrl: '',
     loading: true,
   }
-  
+
   componentDidMount() {
     getUserData().then(user => {
     this.setState({ loading: false });
@@ -111,6 +111,7 @@ class UserVerification extends React.Component {
               <li>freeCodeCamp Full Stack Certification</li>
             </ul>
           </div>
+          <br />
           <button onClick={this.handleSubmit} className="ui positive button">Verify freeCodeCamp Certifications for {this.state.username}</button>
           <p style={{ fontSize: 15, marginTop: 15, marginBottom: 15 }}>
             <i className="red warning circle icon" /><strong>Note:</strong> If your freeCodeCamp username is not <strong>{this.state.username}</strong>, please send an email to Pete's Computer.

--- a/server/helpers/mockData.js
+++ b/server/helpers/mockData.js
@@ -77,7 +77,6 @@ const fakeUsers = [
   'p1xt',
   'bengitter',
   'josh5231',
-  'bonham000'
 ];
 
 const mentorshipSource = [

--- a/server/helpers/user-whitelist.js
+++ b/server/helpers/user-whitelist.js
@@ -1,0 +1,20 @@
+
+/* ****************************************************
+Whitelist legacy freeCodeCamp users so that they can join the app:
+
+This only applies to users whose freeCodeCamp and GitHub
+usernames are different. In that case we just update their
+username to their freeCodeCamp username during the verification
+process.
+
+NOTE: This should be monitored to ensure it works correctly
+if we actually have to use it for someone.
+***************************************************** */
+
+export default {
+
+  /* Format:
+   * GitHub username: freeCodeCamp username
+   */
+
+};


### PR DESCRIPTION
This implements a whitelist functionality for users whose GitHub and freeCodeCamp usernames do not match. If we actually find a user like this, we should carefully make sure this works as expected.

This also improves the text content around what mentorship means in a few places, and adds a few other minor improvements.