### PR TITLE
fixes ...path/:username bug, ui & validation improvements

### DIFF
--- a/client/src/actions/scrape-fcc.js
+++ b/client/src/actions/scrape-fcc.js
@@ -29,7 +29,7 @@ export const scrapeFccStats = (user) => (dispatch) => {
         return item.text();
       });
     }).then(items => {
-      return items.length;
+      return items.length.toString();
     }).catch(err => {
       return null;
     });

--- a/client/src/components/dashboard/Profile/PersonalInfo.js
+++ b/client/src/components/dashboard/Profile/PersonalInfo.js
@@ -14,7 +14,7 @@ const INFO_MESSAGE = 'Don\'t worry, no junkmail. We are asking for your email in
 
 class PersonalInfo extends React.Component {
   shouldComponentUpdate(nextProps) {
-    return !isEqual(this.props, nextProps); 
+    return !isEqual(this.props, nextProps);
   }
   render() {
     const {
@@ -79,7 +79,7 @@ class PersonalInfo extends React.Component {
                 icon="marker icon"
                 inputOptions={INPUT_OPTIONS}
                 onChange={handleInputChange}
-                placeholder="Enter City / State" />
+                placeholder="Enter Location" />
             </ListItem>
             <ListItem>
               <div className="six wide field">

--- a/client/src/components/dashboard/Profile/Public/FCCTables.js
+++ b/client/src/components/dashboard/Profile/Public/FCCTables.js
@@ -27,7 +27,7 @@ const FccTables = ({
   currentStreak,
   browniePoints,
   firstChallenge,
-  totalChallneges,
+  totalChallenges,
 }) => {
   return (
     <div className="row">
@@ -61,7 +61,7 @@ const FccTables = ({
           header="Total Challenges Completed"
           content={
             <div>
-              {totalChallneges}
+              {totalChallenges}
               <Popup
                 inverted
                 wide

--- a/client/src/components/dashboard/Profile/Public/FCCTables.js
+++ b/client/src/components/dashboard/Profile/Public/FCCTables.js
@@ -101,7 +101,7 @@ FccTables.propTypes = {
   currentStreak: propTypes.string.isRequired,
   browniePoints: propTypes.string.isRequired,
   firstChallenge: propTypes.string.isRequired,
-  totalChallneges: propTypes.number.isRequired,
+  totalChallenges: propTypes.number.isRequired,
 }
 
 export default FccTables;

--- a/client/src/components/dashboard/Profile/Public/LocationSteps.js
+++ b/client/src/components/dashboard/Profile/Public/LocationSteps.js
@@ -36,7 +36,7 @@ const Steps = ({ personal }) => {
       <div className="step">
         <i className="marker icon"/>
         <div className="content">
-          <div className="title">City/State</div>
+          <div className="title">Location</div>
         </div>
       </div>
       <div className="step">

--- a/client/src/components/dashboard/Profile/common/RibbonHeader.js
+++ b/client/src/components/dashboard/Profile/common/RibbonHeader.js
@@ -6,6 +6,7 @@ const Container = styled.div`
   margin-top: 8px !important;
   margin-bottom: 8px !important;
   cursor: pointer;
+  display: table;
 `;
 
 const RibbonHeader = ({ content, onClick, showPopUp, subSaveClick, id, showSave }) => {

--- a/client/src/components/dashboard/Profile_Public.js
+++ b/client/src/components/dashboard/Profile_Public.js
@@ -27,7 +27,8 @@ const IMG = styled.img`
 
 const Loader = styled.div`
   height: 200px !important;
-  padding-bottom:  !important;`
+  padding-bottom:  !important;
+  z-index: 0 !important;`
 
 const OneColumnRepoList = styled.div`
   margin-top: 0 !important;
@@ -50,11 +51,13 @@ class PublicProfile extends React.Component {
 
   componentDidMount() {
     document.body.scrollTop = 0;
-    // *** *** *** *** *** *** *** *** *** ***
-    //  ==> ^^ UNCOMMENT WHEN DONE WORKING ON COMPONENT ^^ <==
-    // *** *** *** *** *** *** *** *** *** ***
+    // redirect to community if url user
+    // entered does not contain a valid username
+    if (!this.props.user.username) {
+      this.props.history.push('/dashboard/community');
+    }
     if (!this.props.initialState) {
-      this.props.scrapeFccStats(this.props.match.params.username);
+      this.props.scrapeFccStats(this.props.user.username);
     }
   }
 
@@ -290,11 +293,12 @@ PublicProfile.propTypes = {
 
 const findUser = (community, username) => {
   return community ? community.filter(user =>
-    (user.username === username) && user)[0] : '';
+    (user.username.toLowerCase() === username.toLowerCase()) && user)[0] : '';
 };
 
 const mapStateToProps = ({ community, publicProfileStats, privateChat, user: currentUser }, props) => {
-  const { username } = props.match.params;
+  let username = findUser(community.toJS(), props.match.params.username);
+  if (username) username = username.username;
   let initialState, user = '';
   try {
     initialState = publicProfileStats.get(username);

--- a/client/src/components/dashboard/Profile_Public.js
+++ b/client/src/components/dashboard/Profile_Public.js
@@ -2,6 +2,8 @@ import React from 'react';
 import propTypes from 'prop-types';
 import { connect } from 'react-redux';
 import UserLabel from '../common/UserLabel';
+import SocialList from './Profile/Public/SocialList';
+import { connectScreenSize } from 'react-screen-size';
 import { SubHeader } from './Profile/Public/SkillsRow';
 import LocationSteps from './Profile/Public/LocationSteps';
 import { ThickPaddedBottom, StyledItem } from '../../styles/globalStyles';
@@ -12,7 +14,6 @@ import TableRow from '../dashboard/Profile/Public/TableRow';
 import { saveProfileStats } from '../../actions/views';
 import FCCStatTables from './Profile/Public/FCCTables';
 import Table from '../dashboard/Profile/Public/Table';
-import SocialList from './Profile/Public/SocialList';
 import { defaultUser } from '../../reducers/user';
 import Career from './Profile/Public/CareerRow';
 import styled from 'styled-components';
@@ -22,30 +23,33 @@ import axios from 'axios';
 import { scrapeFccStats } from '../../actions/scrape-fcc.js';
 
 // STYLED COMPONENTS:
-const IMG = styled.img`
-  margin-top: 8px !important;`
+const Avatar = styled.img`
+  margin: 8px auto auto !important;
+  max-height: 270px !important;
+  max-width: 270px !important;`;
 
 const Loader = styled.div`
   height: 200px !important;
   padding-bottom:  !important;
-  z-index: 0 !important;`
+  z-index: 0 !important;`;
 
 const OneColumnRepoList = styled.div`
   margin-top: 0 !important;
-  margin-bottom: 14px !important;`
+  margin-bottom: 14px !important;`;
 
 const NoPadding = styled.div`
-  padding: 0 !important;`
+  padding: 0 !important;`;
 
 const StyledSubHeader = styled(SubHeader)`
-  margin-bottom: 0 !important;`
+  margin-bottom: 0 !important;`;
 
 class PublicProfile extends React.Component {
   constructor(props) {
     super(props);
     const { initialState } = this.props;
     this.state = {
-      ...initialState
+      ...initialState,
+      isTablet: false
     }
   }
 
@@ -59,6 +63,12 @@ class PublicProfile extends React.Component {
     if (!this.props.initialState) {
       this.props.scrapeFccStats(this.props.user.username);
     }
+    
+    window.addEventListener('resize', this.handleResize);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -77,6 +87,14 @@ class PublicProfile extends React.Component {
       this.dynamicHeight = bioHeight;
     } else {
       this.dynamicHeight = contactHeight;
+    }
+  }
+
+  handleResize = (e) => {
+    if (e.target.innerWidth < 992 && e.target.innerWidth > 767) {
+      this.setState({ isTablet: true });
+    } else {
+      this.setState({ isTablet: false });
     }
   }
 
@@ -147,8 +165,8 @@ class PublicProfile extends React.Component {
 
         {/* AVATAR & FCCDATA */}
         <div className="ui celled stackable grid container">
-          <div className="four wide center aligned column">
-            <IMG
+          <div className={`${this.state.isTablet ? 'sixteen' : 'four'} wide center aligned column`}>
+            <Avatar
               src={user.personal.avatarUrl}
               alt={`${user.username}'s avatar'`}
               className="ui fluid circular bordered image" />
@@ -156,9 +174,9 @@ class PublicProfile extends React.Component {
             <UserLabel
               showAvatar={false}
               username={user.username}
-              label={user.mentorship.isMentor ? "Mentor" : "Member"}/>
+              label={this.props.isTablet ? '' : user.mentorship.isMentor ? "Mentor" : "Member"}/>
           </div>
-          <div className="twelve wide column">
+          <div className={`${this.state.isTablet ? 'sixteen' : 'twelve'} wide column`}>
             <LocationSteps personal={user.personal} />
             <NoBottomMargin className="ui celled stackable grid">
               <NoPadding className="sixteen wide center aligned column">
@@ -318,6 +336,12 @@ const mapStateToProps = ({ community, publicProfileStats, privateChat, user: cur
   }
 }
 
+const mapScreenSizeToProps = (screenSize) => {
+  return {
+    isTablet: screenSize['medium'],
+  }
+}
+
 const dispatch = {
   saveProfileStats,
   clearNotifications,
@@ -325,4 +349,5 @@ const dispatch = {
   scrapeFccStats,
 }
 
-export default connect(mapStateToProps, dispatch)(PublicProfile);
+export default connectScreenSize(mapScreenSizeToProps)(
+  connect(mapStateToProps, dispatch)(PublicProfile));

--- a/client/src/reducers/preferencesViewState.js
+++ b/client/src/reducers/preferencesViewState.js
@@ -1,7 +1,7 @@
 import { SAVE_PREFERENCES_VIEW_STATE } from '../actions/types';
 
 const defaultState = {
-  showAll: true,
+  showAll: false,
   showFCC: false,
   showProfile: true,
   showSkills: false,

--- a/client/src/rootReducer.js
+++ b/client/src/rootReducer.js
@@ -7,7 +7,7 @@ import community from './reducers/community';
 import privateChat from './reducers/privateChat';
 import onlineStatus from './reducers/onlineStatus';
 import flashMessages from './reducers/flashMessages';
-import profileViewState from './reducers/profileViewState';
+import profileViewState from './reducers/preferencesViewState';
 import publicProfileStats from './reducers/publicProfileStats';
 
 export default combineReducers({


### PR DESCRIPTION
- fixes bug described in issue #129 
- makes improvements to responsiveness at tablet resolutions for public profile page (looked a bit funny before, username label did not render right and user avatar would be at the top of a tall, narrow column, this stacks the containers a bit earlier using some custom event listeners)
- improves validation code for preferences page - if a user has github data that breaks validation rules, previous validation would not pick up on it (ex. length of display name and location) since user would not be explicitly typing it in. But it is still important to limit the length of these sections to ensure proper UI rendering. We could approach this another way down the line, GH seems to just hide overflow for long location entries and such, but this works for now.
- other random extremely minor fixes
closes #129