### PR TITLE
add beta testers guide, routing fixes in Chat and PublicProfile 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
+### A note to those helping us to beta test this app:
+First of all, a sincere __thank you__ from the FCCAN team for taking some time to help us find out if this app is ready for production. We've worked very hard on this so far, and we want to be sure it is in the best possible shape before releasing it to the general freeCodeCamp public. In order to do this, we need your help! We feel fairly confident that this app is in a pretty good place, but we need real users, using it as intended, to help us uncover any bugs that we may have missed.
+
+A couple of things we'd like to point out before you get started:
+- According to the rules of the organization, you must have at least one FCC cert to participate (otherwise your account will not authenticate).
+- This is a V1.0.0 release - our goal has been to build an MVP that works, and works well, without getting too bogged down in overly complex features. That said, you may come up with some awesome ideas, and if you do, please let us know! However, in keeping with this theme, any fundamental changes or major features will not be entertained until post-production. We have an issue tracking a few things we already have in mind [here](https://github.com/FCC-Alumni/alumni-network/issues/139).
+- Please try to use every feature you can, and let's see if we can break this thing!
+- What we're really looking to uncover are things like:
+  - bugs, big or small
+  - functionality flaws
+  - any cross browser/platform/device issues that we may have missed
+  - typos in our copy
+  - etc., etc.
+- If you uncover a bug, or have a suggestion or idea, please open an issue, and myself (@no-stack-dub-sack) or @bonham000 will check it out reply as soon as we can. For the time being, please do not submit a PR __[1]__.
+
+__[1]__ Lastly, while this _is_, and _always will be_, a completely open source project, we are currently a very small team, and based on how close we are to our first release, we are not prepared to accept contributions from other campers. For now, while we are focused on ironing out the kinks, and without a contributing guide in place, bringing anyone else into the mix and up to speed is too large a challenge. Once we are in production, though, we will welcome contributions with open arms!
+
+
+__Thanks__ again! We really look forward to your feedback, suggestions, and constructive criticism, and above all, we hope you enjoy the app! Happy networking!
+
+***
+
 # This is the official home of the freeCodeCamp Alumni Network
 
-## Welcome
+freeCodeCamp has an incredible and vibrant international community. We built this app specifically to try and cultivate relationships among experienced campers.
+
+Currently, the [FCC Forum](https://forum.freeCodeCamp.com), [Gitter](https://gitter.im/freeCodeCamp), and other resources provide ample opportunities for campers at any skill level. We wanted to create an environment specifically for more experienced campers who are looking for advanced collaborative projects or mentorship opportunities, as a mentor or mentee.
+
+Our authentication process verifies the FCC progress of users, and only admits students who have completed at least one FCC Certificate (Note: User's will
+have to make their FCC profiles public for this validation to work).
+
+Our goal is to create a focused community of like-minded individuals who can benefit from each others culminated experience and expertise, whether in new technologies, programming skills, or career advice.

--- a/client/src/components/dashboard/Chat/ChatController.js
+++ b/client/src/components/dashboard/Chat/ChatController.js
@@ -251,14 +251,26 @@ export const findMentors = (community) => {
   }));
 };
 
+const findUser = (community, username) =>
+  community.filter(u => u.username.toLowerCase() === username.toLowerCase() && u)[0];
+
 const mapStateToProps = ({ user, chat, privateChat, community, onlineStatus }, props) => {
-  const { username } = props.match.params;
+  // handle manually typed chat routes, allow case insensitivity.
+  // if user types route for own username, set to null
+  // to render main chat component.
+  const USR_PARAM = props.match.params.username ? props.match.params.username : '';
+  let username = findUser(community.toJS(), USR_PARAM);
+  if (username && username.username !== user.username) {
+    username = username.username;
+  } else {
+    username = null;
+  }
+  /* This is all to account for this component mounting before the parent AppContainer
+  has finished fetching chat history from the server... (i.e. user refreshes on a
+  private chat route. This isn't ideal but the alternative is implement a lot of
+  loading state and conditional rendering in the components for all of the
+  dispatches for chat, community, private chat, etc.) For now this will do: ******/
   if (username) {
-    /* This is all to account for this component mounting before the parent AppContainer
-       has finished fetching chat history from the server... (i.e. user refreshes on a
-       private chat route. This isn't ideal but the alternative is implement a lot of
-       loading state and conditional rendering in the components for all of the
-       dispatches for chat, community, private chat, etc.) For now this will do: ******/
     let chat = List();
     let conversantAvatar = '';
     let totalNotifications = 0;

--- a/client/src/components/dashboard/Landing.js
+++ b/client/src/components/dashboard/Landing.js
@@ -14,10 +14,10 @@ export default () => (
     <div className="ui segment" style={{ fontSize: 18, paddingBottom: 35 }}>
       {image('/images/fcc_hands_in_logo.svg', 'left')}
       <p>
-        We built this app to try to foster networking and mentorship opportunities among
+        We built this app to foster networking and mentorship opportunities among
         freeCodeCamp alumni. When we looked at the FCC community we saw that there are
         many opportunities for members to connect with each other, but few that are focused on
-        the professional side. Our community here is intended to be very focused on campers
+        the professional side. Our community is intended to be very focused on campers
         who are looking to level-up their skills, work on professional level projects, or
         focus on career-related goals, such as interviewing.
       </p>
@@ -30,7 +30,7 @@ export default () => (
       <p>
         One of the key features of this community is the focus on mentorship. We encourage anyone
         interested in becoming a mentor to indicate this on their profile and describe the core
-        competencies they could coach others in. Because members must have a FCC certification to
+        competencies they feel comfortable coaching others in. Because members must have an FCC certification to
         join, we feel confident that everyone will have some skills they could help mentor others in.
       </p>
       {image('/images/fcc_learn_logo.svg', 'left')}
@@ -42,7 +42,7 @@ export default () => (
       {image('/images/fcc_high_five_logo.svg', 'right')}
       <p>
         Thanks for joining! We hope this becomes a useful extension to the freeCodeCamp
-        experience for all who join. Our essential goal is here to foster meaningful connections
+        experience for all who join. Our essential goal here is to foster meaningful connections
         among campers and continue to encourage the development of great software.
       </p>
     </div>

--- a/client/src/components/dashboard/PublicProfile.js
+++ b/client/src/components/dashboard/PublicProfile.js
@@ -54,15 +54,11 @@ class PublicProfile extends React.Component {
 
   componentDidMount() {
     document.body.scrollTop = 0;
-    // redirect to community if url user
-    // entered does not contain a valid username
-    if (!this.props.loading && !this.props.user.username) {
-      this.props.history.push('/dashboard/community');
-    }
+    // handles navigation to profile
+    // through built in FCCAN links
     if (!this.props.initialState) {
       this.props.scrapeFccStats(this.props.user.username);
     }
-
     window.addEventListener('resize', this.handleResize);
   }
 
@@ -73,6 +69,8 @@ class PublicProfile extends React.Component {
   componentWillReceiveProps(nextProps) {
     const { initialState } = nextProps;
     if (initialState) this.setState({ ...initialState });
+    // handles manual navigation to profile, i.e. typed url,
+    // if username param is invalid, redirects to community
     if (!nextProps.loading && !nextProps.user.username) {
       this.props.history.push('/dashboard/community');
     } else if (!nextProps.loading && !nextProps.initialState) {
@@ -318,30 +316,31 @@ PublicProfile.propTypes = {
 }
 
 const findUser = (community, username) => {
-  return community ? community.filter(user =>
-    (user.username.toLowerCase() === username.toLowerCase()) && user)[0] : null;
+  return community ? community.filter(user => {
+    return user.username.toLowerCase() === username.toLowerCase() && user;
+  })[0] : null;
 };
 
 const mapStateToProps = ({ community, publicProfileStats, privateChat, user: currentUser }, props) => {
   let username = findUser(community.toJS(), props.match.params.username);
   if (username) username = username.username;
-  let initialState, user = '';
+  let initialState, user;
   try {
     initialState = publicProfileStats.get(username);
   } catch (e) {
-    console.log(e)
+    console.warn('Profile component is waiting on props');
   }
   try {
     user = findUser(community.toJS(), username);
   } catch (e) {
-    console.log(e)
+    console.warn('Profile component is waiting on props');
   }
   return {
     currentUser: currentUser.username,
     user: user ? user : defaultUser,
+    loading: !community.size, // mock loading state based on community...
     initialState,
     privateChat,
-    loading: !community.size, // mock loading state based on community...
   }
 }
 


### PR DESCRIPTION
@bonham000 your code did work on my computer, for whatever reason, the key was definitely adding the scrape function in CWRP. 

Did make some slight changes, the redirect code was redundant and only needed in CWRP, so took it out of CDM &mdash; this all seems to be working well on my machine. I can:
- type in profile routes using any case as long as username is valid
- follow direct links to profiles from any component with link
- be redirected to community when typing in invalid profile url

The same goes for Chat Controller, except added a little extra code to make sure users cannot navigate to their own chat route (which I was able to do previously). 

The only slight issue is that if a user types in their own route, or the route of a user that does not exist, main chat renders, but user is technically not redirected, so the path that appears in the address bar is technically an invalid path. Tried to get around this by redirecting to main chat, but since we are already there, this caused some issues. Not sure if this could be a problem or not, but for now, it just seems to be an aesthetic issue.  