### PR TITLE
Fixes chat redirect, creates honorary user list

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,7 +19,7 @@ mongoose.connect(process.env.MONGO_URL, () => console.log('Mongoose connected'))
 
 /*=========== Populating DB with user data =====>
 This will only save users if they don't exist locally yet */
-require('./server/helpers/mockData');
+// require('./server/helpers/mockData');
 
 // initialize Express app and setup routes
 const app = express();

--- a/server/helpers/user-whitelist.js
+++ b/server/helpers/user-whitelist.js
@@ -11,10 +11,29 @@ NOTE: This should be monitored to ensure it works correctly
 if we actually have to use it for someone.
 ***************************************************** */
 
-export default {
+export const whitelist = {
 
   /* Format:
    * GitHub username: freeCodeCamp username
    */
+
+};
+
+/* ****************************************************
+Provided honorary access to certain FCC users:
+
+This applies to certain users who for exceptional circumstances
+should be able to join the network, but do not have any
+certifications.
+***************************************************** */
+
+export const honoraryMembers = {
+
+  /* Format:
+   * username: reason for membership (this is just for our record and has no function)
+   */
+
+   quincylarson: 'He founded freeCodeCamp',
+   p1xt: 'Prolific freeCodeCamp community member',
 
 };

--- a/server/routes/private-chat.js
+++ b/server/routes/private-chat.js
@@ -149,7 +149,8 @@ router.post('/api/private-chat/clear-notifications', isAuthenticated, (req, res)
         res.sendStatus(200);
       });
     } else {
-      res.sendStatus(404);
+      /* there is no conversation yet */
+      res.end();
     }
   });
 });

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -11,7 +11,10 @@ import {
   getBackEndCert,
   getDataVisCert,
 } from '../helpers/getCerts';
-import whitelist from '../helpers/user-whitelist';
+import {
+  whitelist,
+  honoraryMembers,
+} from '../helpers/user-whitelist';
 
 const router = express.Router();
 
@@ -40,7 +43,9 @@ router.post('/api/verify-credentials', isAuthenticated, (req, res) => {
   // process FCC verification...
   axios.all([getFrontEndCert(username), getBackEndCert(username), getDataVisCert(username)])
   .then(axios.spread((frontCert, backCert, dataCert) => {
-    if ((frontCert.request._redirectCount +
+    if (username in honoraryMembers) {
+      return true;
+    } else if ((frontCert.request._redirectCount +
       backCert.request._redirectCount +
       dataCert.request._redirectCount) >= 3 ) {
       // NOTE: temporarily set to true to allow anyone in (for development):


### PR DESCRIPTION
@no-stack-dub-sack this should fix the redirect issue in chat. This also creates a list of honorary users who lack FCC certs, and it disables populating the mock users for now. And it fixes a minor bug I found in chat.

Since the diff looks like crap with red, this version:

``` javascript
const findUser = (community, username) =>
  community.filter(u => u.username.toLowerCase() === username.toLowerCase() && u).first();
```

works to search the community list without converting it to JavaScript from an Immutable list. All the Immutable data structures implement common methods like `map`, `filter`, `reduce`, etc. which behave as you would expect. Also I guess its worth knowing about that with Immutable some of the costly operations are actually the conversions to and from JavaScript.