### PR TITLE
preferences component refactor

### DIFF
--- a/client/src/components/dashboard/Profile/Preferences/Career.js
+++ b/client/src/components/dashboard/Profile/Preferences/Career.js
@@ -44,7 +44,7 @@ class Career extends React.Component {
       showPopUp,
       clearForm,
       showCareer,
-      subSaveClick,
+      saveSection,
       bigBottomMargin,
       handleInputChange,
       handleRadioChange,
@@ -58,7 +58,7 @@ class Career extends React.Component {
           id="careerPopUp"
           showSave={showCareer}
           showPopUp={showPopUp}
-          subSaveClick={subSaveClick}
+          saveSection={saveSection}
           onClick={() => toggle('showCareer')} />
         <OuterTransitionContainer
           isExpanded={showCareer}

--- a/client/src/components/dashboard/Profile/Preferences/Career.js
+++ b/client/src/components/dashboard/Profile/Preferences/Career.js
@@ -78,12 +78,12 @@ class Career extends React.Component {
               <label>Are you employed as a software developer?</label>
               <RadioButton
                 label='Yes'
-                name="working"
+                name="isEmployed"
                 onChange={handleRadioChange}
                 checked={working === 'yes' && true} />
               <RadioButton
                 label='No'
-                name="working"
+                name="isEmployed"
                 onChange={handleRadioChange}
                 checked={working === 'no' && true}  />
             </div>

--- a/client/src/components/dashboard/Profile/Preferences/Collaboration.js
+++ b/client/src/components/dashboard/Profile/Preferences/Collaboration.js
@@ -17,7 +17,7 @@ export default class Collaboration extends React.Component {
       username,
       showPopUp,
       saveChanges,
-      subSaveClick,
+      saveSection,
       saveProjectsList,
       showCollaboration,
     } = this.props;
@@ -27,7 +27,7 @@ export default class Collaboration extends React.Component {
           id="projectsPopUp"
           content="Collaboration"
           showPopUp={showPopUp}
-          subSaveClick={subSaveClick}
+          saveSection={saveSection}
           showSave={showCollaboration}
           onClick={() => toggle('showCollaboration')} />
         <TransitionContainer isExpanded={showCollaboration}>

--- a/client/src/components/dashboard/Profile/Preferences/Mentorship.js
+++ b/client/src/components/dashboard/Profile/Preferences/Mentorship.js
@@ -19,7 +19,7 @@ class Mentorship extends React.Component {
       isMentor,
       isMentee,
       showPopUp,
-      subSaveClick,
+      saveSection,
       showMentorship,
       mentorshipSkills,
       toggleMentorship,
@@ -33,7 +33,7 @@ class Mentorship extends React.Component {
           showPopUp={showPopUp}
           showSave={showMentorship}
           content="Mentorship Program"
-          subSaveClick={subSaveClick}
+          saveSection={saveSection}
           onClick={() => toggle('showMentorship')} />
         <TransitionContainer isExpanded={showMentorship}>
           <MessageBox
@@ -84,7 +84,7 @@ Mentorship.propTypes = {
   toggle: propTypes.func.isRequired,
   isMentor: propTypes.bool.isRequired,
   showPopUp: propTypes.bool.isRequired,
-  subSaveClick: propTypes.func.isRequired,
+  saveSection: propTypes.func.isRequired,
   showMentorship: propTypes.bool.isRequired,
   toggleMentorship: propTypes.func.isRequired,
   handleInputChange: propTypes.func.isRequired,

--- a/client/src/components/dashboard/Profile/Preferences/PersonalInfo.js
+++ b/client/src/components/dashboard/Profile/Preferences/PersonalInfo.js
@@ -32,7 +32,7 @@ class PersonalInfo extends React.Component {
       isPrivate,
       displayName,
       showProfile,
-      subSaveClick,
+      saveSection,
       handleInputChange,
       handleCountryChange,
       toggleEmailVisibilty,
@@ -45,7 +45,7 @@ class PersonalInfo extends React.Component {
           content="Personal Info"
           showPopUp={showPopUp}
           showSave={showProfile}
-          subSaveClick={subSaveClick}
+          saveSection={saveSection}
           onClick={() => toggle('showProfile')} />
         <TransitionContainer isExpanded={showProfile} className="ui form">
           <Container className="ui list">

--- a/client/src/components/dashboard/Profile/Preferences/SkillsAndInterests.js
+++ b/client/src/components/dashboard/Profile/Preferences/SkillsAndInterests.js
@@ -16,7 +16,7 @@ export default class SkillsAndInterests extends React.Component {
       showPopUp,
       coreSkills,
       showSkills,
-      subSaveClick,
+      saveSection,
       skillsOptions,
       handleAddSkill,
       codingInterests,
@@ -31,7 +31,7 @@ export default class SkillsAndInterests extends React.Component {
           showPopUp={showPopUp}
           showSave={showSkills}
           content="Skills & Interests"
-          subSaveClick={subSaveClick}
+          saveSection={saveSection}
           id="skillsAndInterestsPopUp"
           onClick={() => toggle('showSkills')} />
         <TransitionContainer isExpanded={showSkills}>

--- a/client/src/components/dashboard/Profile/Preferences/Social.js
+++ b/client/src/components/dashboard/Profile/Preferences/Social.js
@@ -25,7 +25,7 @@ export default class Social extends React.Component {
       showPopUp,
       showSocial,
       saveChanges,
-      subSaveClick,
+      saveSection,
       handleInputChange,
     } = this.props;
     return (
@@ -35,7 +35,7 @@ export default class Social extends React.Component {
           id="socialPopUp"
           showSave={showSocial}
           showPopUp={showPopUp}
-          subSaveClick={subSaveClick}
+          saveSection={saveSection}
           onClick={() => toggle('showSocial')} />
         <TransitionContainer isExpanded={showSocial}>
           <MessageBox

--- a/client/src/components/dashboard/Profile/Preferences/common/RibbonHeader.js
+++ b/client/src/components/dashboard/Profile/Preferences/common/RibbonHeader.js
@@ -9,14 +9,14 @@ const Container = styled.div`
   display: table;
 `;
 
-const RibbonHeader = ({ content, onClick, showPopUp, subSaveClick, id, showSave }) => {
+const RibbonHeader = ({ content, onClick, showPopUp, saveSection, id, showSave }) => {
   return (
     <Container>
       <div className="ui green large ribbon label" onClick={onClick}>
         {content}
       { showSave &&
         <div className="detail">
-          <i onClick={subSaveClick} id={id} title="Save Section" className="saveSection save icon" />
+          <i onClick={saveSection} id={id} title="Save Section" className="saveSection save icon" />
         </div> }
       </div>
     { showSave &&


### PR DESCRIPTION
An attempt at making the code in the preferences page component a bit "cleaner", i.e. more readable, separating out functions so that each only does one thing, better commenting, better naming etc. 

A quick (and incomplete) summary:
- improved validations code
    - converted ugly if/else blocks into switch statements for improved readability
    - created `isFieldValid` function which separates out code that was being handled by `isSectionValid`
     - eliminated redundancies such as final set errors state expression, and certain shared validations 
- renamed functions to clearer names
- split profile strength logic into own function, instead of as part of `isPageValid`
- organized functions into sections - handleChange, validations, helpers, etc.